### PR TITLE
Feature: Selective loading of ipinfo and cloud ip ranges

### DIFF
--- a/tests/test_models/test_models.py
+++ b/tests/test_models/test_models.py
@@ -36,3 +36,17 @@ def test_none_cloud_providers() -> None:
     """Test that None cloud_providers is handled correctly"""
     config = SecurityConfig(ipinfo_token="test", block_cloud_providers=None)
     assert config.block_cloud_providers == set()
+
+
+def test_missing_ipinfo_token() -> None:
+    """Test that missing ipinfo_token raises a ValueError"""
+    with pytest.raises(ValueError):
+        SecurityConfig(ipinfo_token=None, blocked_countries=["US"])
+
+    with pytest.raises(ValueError):
+        SecurityConfig(ipinfo_token=None, whitelist_countries=["US"])
+
+    with pytest.raises(ValueError):
+        SecurityConfig(
+            ipinfo_token=None, blocked_countries=["US"], whitelist_countries=["US"]
+        )

--- a/tests/test_utils/test_request_checks.py
+++ b/tests/test_utils/test_request_checks.py
@@ -480,10 +480,10 @@ async def test_is_ip_allowed_cloud_providers(
     mocker.patch.object(
         cloud_handler,
         "is_cloud_ip",
-        side_effect=lambda ip, providers: ip.startswith("13."),
+        side_effect=lambda ip, *_: ip.startswith("13."),
     )
 
-    config = SecurityConfig(ipinfo_token=IPINFO_TOKEN, block_cloud_providers={"AWS"})
+    config = SecurityConfig(block_cloud_providers={"AWS"})
 
     assert await is_ip_allowed("127.0.0.1", config)
     assert not await is_ip_allowed("13.59.255.255", config)


### PR DESCRIPTION
## Description
With these changes, the middleware and the cloud_handler singleton will not perform any loading operations regarding ipinfo and cloud ip ranges if the user does not specify any whitelisted/blacklisted countries and blocked clouds (accordingly).

## Related Issue
NA

## Motivation and Context
The security middleware startup has a relatively high time cost of downloading the ipinfo db and requesting three different cloud providers for chunky json's of ip range. This information is all loaded regardless of the user configuration. It is more efficient to load things as needed per the user config.

## Type of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [?] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change
- [x] Performance improvement
- [x] Code cleanup or refactoring

## How Has This Been Tested?
Covered all previous tests + added new ones to maintain 100% coverage.

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project (PEP 8, black formatting)
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have checked that my changes don't introduce any new warnings or errors
- [ ] I have updated the version number if necessary
- [ ] I have added any new dependencies to the appropriate requirements file