### PR TITLE
feat(agent): clear missing-package error, opt-in strict, on_error hook (O1/O2)

### DIFF
--- a/guard/middleware.py
+++ b/guard/middleware.py
@@ -13,6 +13,7 @@ from guard_core.core.responses import ErrorResponseFactory, ResponseContext
 from guard_core.core.routing import RouteConfigResolver, RoutingContext
 from guard_core.core.validation import RequestValidator, ValidationContext
 from guard_core.decorators.base import BaseSecurityDecorator, RouteConfig
+from guard_core.exceptions import AgentPackageNotInstalledError
 from guard_core.handlers.cloud_handler import cloud_handler
 from guard_core.handlers.cors_handler import CorsHandler, is_preflight
 from guard_core.handlers.ratelimit_handler import RateLimitManager
@@ -20,7 +21,11 @@ from guard_core.handlers.security_headers_handler import security_headers_manage
 from guard_core.models import SecurityConfig
 from guard_core.protocols import AgentHandlerProtocol, GuardResponse
 from guard_core.protocols.request_protocol import GuardRequest
-from guard_core.utils import extract_client_ip, setup_custom_logging
+from guard_core.utils import (
+    extract_client_ip,
+    invoke_error_hook,
+    setup_custom_logging,
+)
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.responses import Response as StarletteResponse
 from starlette.types import ASGIApp
@@ -63,30 +68,27 @@ class SecurityMiddleware(BaseHTTPMiddleware):
             self.redis_handler = RedisManager(config)
 
         self.agent_handler: AgentHandlerProtocol | None = None
+        self.agent_degraded = False
         if config.enable_agent:
             try:
-                from guard_agent import guard_agent
-            except ImportError:
-                self.logger.warning(
-                    "Agent enabled but guard_agent package not installed. "
-                    "Install with: pip install guard-agent"
-                )
-            else:
                 agent_config = config.to_agent_config()
-                if agent_config is None:
-                    self.logger.error(
-                        "Agent enabled but configuration is invalid. "
-                        "Check agent_api_key and other required fields."
-                    )
-                else:
-                    try:
-                        self.agent_handler = cast(
-                            AgentHandlerProtocol, guard_agent(agent_config)
-                        )
-                        self.logger.info("Guard Agent initialized successfully")
-                    except Exception as e:
-                        self.logger.error(f"Failed to initialize Guard Agent: {e}")
-                        self.logger.warning("Continuing without agent functionality")
+                from guard_agent import guard_agent
+
+                self.agent_handler = cast(
+                    AgentHandlerProtocol, guard_agent(cast(Any, agent_config))
+                )
+                self.logger.info("Guard Agent initialized successfully")
+            except AgentPackageNotInstalledError as e:
+                self._on_agent_init_failed(
+                    config,
+                    e,
+                    "Agent enabled but guard-agent is not installed. "
+                    "Install with: pip install fastapi-guard[agent]",
+                )
+            except Exception as e:
+                self._on_agent_init_failed(
+                    config, e, f"Failed to initialize Guard Agent: {e}"
+                )
 
         self.security_pipeline: SecurityCheckPipeline | None = None
 
@@ -221,12 +223,22 @@ class SecurityMiddleware(BaseHTTPMiddleware):
     def guard_response_factory(self) -> StarletteResponseFactory:
         return self._guard_response_factory
 
+    def _on_agent_init_failed(
+        self, config: SecurityConfig, exc: Exception, message: str
+    ) -> None:
+        self.agent_degraded = True
+        invoke_error_hook(config.on_error, "agent_init", exc, {})
+        if config.agent_strict:
+            raise exc
+        self.logger.error(message)
+        self.logger.warning("Continuing without agent functionality")
+
     @property
     def agent_stats(self) -> dict[str, Any]:
         if self.agent_handler is None:
-            return {"enabled": False}
+            return {"enabled": False, "degraded": self.agent_degraded}
         handler_stats = cast(Any, self.agent_handler).get_stats()
-        return {"enabled": True, **handler_stats}
+        return {"enabled": True, "degraded": self.agent_degraded, **handler_stats}
 
     def _build_security_pipeline(self) -> None:
         from guard_core.core.checks import (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,9 @@ Changelog = "https://github.com/rennf93/fastapi-guard/blob/master/CHANGELOG.md"
 "Live Playground" = "https://playground.guard-core.com"
 
 [project.optional-dependencies]
+agent = [
+    "guard-agent",
+]
 dev = [
     "aiohttp",
     "bandit[toml]",

--- a/tests/test_middleware/test_agent_init_clarity.py
+++ b/tests/test_middleware/test_agent_init_clarity.py
@@ -1,0 +1,85 @@
+import logging
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from fastapi import FastAPI
+from guard_core.exceptions import AgentPackageNotInstalledError
+from guard_core.models import SecurityConfig
+
+from guard.middleware import SecurityMiddleware
+
+
+def _config(**kwargs: Any) -> SecurityConfig:
+    return SecurityConfig(enable_agent=True, agent_api_key="x", **kwargs)
+
+
+async def test_missing_agent_package_fails_soft_with_clear_message(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    app = FastAPI()
+    config = _config()
+    with patch.object(
+        SecurityConfig,
+        "to_agent_config",
+        side_effect=AgentPackageNotInstalledError("nope"),
+    ):
+        with caplog.at_level(logging.ERROR):
+            middleware = SecurityMiddleware(app, config=config)
+
+    assert middleware.agent_handler is None
+    assert middleware.agent_degraded is True
+    assert any("pip install fastapi-guard[agent]" in r.message for r in caplog.records)
+
+
+async def test_missing_agent_package_strict_raises() -> None:
+    app = FastAPI()
+    config = _config(agent_strict=True)
+    with patch.object(
+        SecurityConfig,
+        "to_agent_config",
+        side_effect=AgentPackageNotInstalledError("nope"),
+    ):
+        with pytest.raises(AgentPackageNotInstalledError):
+            SecurityMiddleware(app, config=config)
+
+
+async def test_agent_init_failure_fires_on_error_hook() -> None:
+    app = FastAPI()
+    captured: list[tuple[str, BaseException, dict[str, Any]]] = []
+    config = _config(on_error=lambda s, e, c: captured.append((s, e, c)))
+    err = AgentPackageNotInstalledError("nope")
+    with patch.object(SecurityConfig, "to_agent_config", side_effect=err):
+        SecurityMiddleware(app, config=config)
+
+    assert captured[0][0] == "agent_init"
+    assert captured[0][1] is err
+
+
+async def test_agent_stats_reports_degraded_after_init_failure() -> None:
+    app = FastAPI()
+    config = _config()
+    with patch.object(
+        SecurityConfig,
+        "to_agent_config",
+        side_effect=AgentPackageNotInstalledError("nope"),
+    ):
+        middleware = SecurityMiddleware(app, config=config)
+
+    assert middleware.agent_stats == {"enabled": False, "degraded": True}
+
+
+async def test_generic_agent_init_failure_fails_soft(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    app = FastAPI()
+    config = _config()
+    with patch.object(
+        SecurityConfig, "to_agent_config", side_effect=RuntimeError("boom")
+    ):
+        with caplog.at_level(logging.ERROR):
+            middleware = SecurityMiddleware(app, config=config)
+
+    assert middleware.agent_handler is None
+    assert middleware.agent_degraded is True
+    assert any("Failed to initialize Guard Agent" in r.message for r in caplog.records)

--- a/tests/test_middleware/test_security_middleware.py
+++ b/tests/test_middleware/test_security_middleware.py
@@ -1794,11 +1794,11 @@ async def test_ipv6_cidr_whitelist_blacklist(
         response = await client.get("/", headers={"X-Forwarded-For": "2001:db8:1::1"})
         assert response.status_code == status.HTTP_200_OK
 
-        # IPv6 address in blacklisted CIDR (blacklist overrides whitelist)
+        # IPv6 in both a whitelist CIDR and the blacklist: whitelist overrides
         response = await client.get(
             "/", headers={"X-Forwarded-For": "2001:db8:dead::beef"}
         )
-        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert response.status_code == status.HTTP_200_OK
 
         # IPv6 address outside whitelisted CIDR
         response = await client.get("/", headers={"X-Forwarded-For": "2001:db9::1"})
@@ -1834,7 +1834,7 @@ async def test_mixed_ipv4_ipv6_handling(security_config_redis: SecurityConfig) -
         assert response.status_code == status.HTTP_200_OK
 
         response = await client.get("/", headers={"X-Forwarded-For": "192.168.1.100"})
-        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert response.status_code == status.HTTP_200_OK
 
         # IPv6 addresses
         response = await client.get("/", headers={"X-Forwarded-For": "::1"})
@@ -1846,7 +1846,7 @@ async def test_mixed_ipv4_ipv6_handling(security_config_redis: SecurityConfig) -
         response = await client.get(
             "/", headers={"X-Forwarded-For": "2001:db8:dead::beef"}
         )
-        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert response.status_code == status.HTTP_200_OK
 
 
 @pytest.mark.asyncio
@@ -2057,7 +2057,7 @@ async def test_agent_stats_returns_disabled_when_agent_handler_unset() -> None:
     config = SecurityConfig(enable_agent=False)
     middleware = SecurityMiddleware(app, config=config)
     assert middleware.agent_handler is None
-    assert middleware.agent_stats == {"enabled": False}
+    assert middleware.agent_stats == {"enabled": False, "degraded": False}
 
 
 async def test_agent_stats_returns_enabled_with_agent_handler_stats() -> None:


### PR DESCRIPTION
## Summary

Design-partner feedback **O1/O2** (agent-error clarity), fastapi-guard adapter half. Mirrors the guard-core 3.2.0 engine change (#25) and guard-agent transport hook (#20).

When `enable_agent=True` but the `guard-agent` package is missing, `to_agent_config()` now raises `AgentPackageNotInstalledError` (guard-core 3.2.0). The middleware catches it and surfaces an **actionable** message — `pip install fastapi-guard[agent]` — instead of the old misleading "check `agent_api_key`" path.

### Behavior
- **Fail-soft by default**: agent-init failures log + continue, set `agent_degraded`, and fire `on_error(stage="agent_init", exc, {})`.
- **Opt-in fail-fast**: `agent_strict=True` re-raises, for deployments where the agent is mandatory.
- **Observable**: degraded state is exposed via `agent_stats` (`{"enabled": ..., "degraded": ...}`).
- New `[agent]` optional-dependency extra.

### Tests
- New `tests/test_middleware/test_agent_init_clarity.py` — missing-package fail-soft message, `agent_strict` raises, `on_error` fires with `stage="agent_init"`, `agent_stats` degraded, generic-failure fail-soft.
- Updated IPv6/IPv4 whitelist-vs-blacklist assertions for guard-core 3.2.0 **explicit-whitelist-overrides-blacklist** precedence (O5).
- Full suite: 242 passed, 100% line + branch coverage, zero warnings.

> [!NOTE]
> Depends on the `AgentPackageNotInstalledError` symbol introduced in **guard-core 3.2.0**. Merge/release alongside the coordinated guard-core 3.2.0 publish.