### PR TITLE
refactor(exports): single-source __all__ from guard_core (O3)

### DIFF
--- a/guard/__init__.py
+++ b/guard/__init__.py
@@ -1,61 +1,36 @@
-from importlib.metadata import PackageNotFoundError
-from importlib.metadata import version as _pkg_version
+from importlib.metadata import PackageNotFoundError, version as _pkg_version
 
+import guard_core
 from guard_core import (
-    BehaviorRule,
-    BehaviorTracker,
-    CloudManager,
-    GeoIPHandler,
-    GuardRequest,
-    GuardResponse,
-    GuardResponseFactory,
-    IPBanManager,
-    IPInfoManager,
-    RateLimitManager,
-    RedisHandlerProtocol,
-    RedisManager,
-    RouteConfig,
-    SecurityConfig,
-    SecurityDecorator,
-    SecurityHeadersManager,
-    cloud_handler,
-    ip_ban_manager,
-    rate_limit_handler,
-    redis_handler,
-    security_headers_manager,
-    sus_patterns_handler,
+    BehaviorRule as BehaviorRule,
+    BehaviorTracker as BehaviorTracker,
+    CloudManager as CloudManager,
+    GeoIPHandler as GeoIPHandler,
+    GuardRequest as GuardRequest,
+    GuardResponse as GuardResponse,
+    GuardResponseFactory as GuardResponseFactory,
+    IPBanManager as IPBanManager,
+    IPInfoManager as IPInfoManager,
+    RateLimitManager as RateLimitManager,
+    RedisHandlerProtocol as RedisHandlerProtocol,
+    RedisManager as RedisManager,
+    RouteConfig as RouteConfig,
+    SecurityConfig as SecurityConfig,
+    SecurityDecorator as SecurityDecorator,
+    SecurityHeadersManager as SecurityHeadersManager,
+    cloud_handler as cloud_handler,
+    ip_ban_manager as ip_ban_manager,
+    rate_limit_handler as rate_limit_handler,
+    redis_handler as redis_handler,
+    security_headers_manager as security_headers_manager,
+    sus_patterns_handler as sus_patterns_handler,
 )
 
-from guard.middleware import SecurityMiddleware
+from guard.middleware import SecurityMiddleware as SecurityMiddleware
 
 try:
     __version__ = _pkg_version("fastapi-guard")
 except PackageNotFoundError:
     __version__ = "0.0.0+unknown"
 
-__all__ = [
-    "__version__",
-    "SecurityMiddleware",
-    "SecurityConfig",
-    "SecurityDecorator",
-    "RouteConfig",
-    "BehaviorTracker",
-    "BehaviorRule",
-    "ip_ban_manager",
-    "IPBanManager",
-    "cloud_handler",
-    "CloudManager",
-    "IPInfoManager",
-    "rate_limit_handler",
-    "RateLimitManager",
-    "redis_handler",
-    "RedisManager",
-    "security_headers_manager",
-    "SecurityHeadersManager",
-    "sus_patterns_handler",
-    "GeoIPHandler",
-    "RedisHandlerProtocol",
-    "GuardRequest",
-    "GuardResponse",
-    "GuardResponseFactory",
-]
+__all__ = ["__version__", "SecurityMiddleware", *guard_core.__all__]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,6 +132,9 @@ select = [
     "I",
 ]
 
+[tool.ruff.lint.isort]
+combine-as-imports = true
+
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]
@@ -140,6 +143,9 @@ asyncio_default_fixture_loop_scope = "function"
 addopts = "--cov=guard --cov-branch --cov-report=term-missing"
 markers = [
     "asyncio: mark tests as async"
+]
+filterwarnings = [
+    "ignore:ipinfo_.* is deprecated:DeprecationWarning",
 ]
 
 [tool.coverage.run]

--- a/tests/test_reexports.py
+++ b/tests/test_reexports.py
@@ -8,6 +8,18 @@ def test_all_exports_importable() -> None:
         assert hasattr(guard, name), f"{name} not found in guard module"
 
 
+def test_all_derives_from_guard_core_exports() -> None:
+    import guard_core
+
+    import guard
+
+    assert set(guard.__all__) == {
+        "__version__",
+        "SecurityMiddleware",
+        *guard_core.__all__,
+    }
+
+
 def test_security_middleware_importable() -> None:
     from guard.middleware import SecurityMiddleware
 


### PR DESCRIPTION
## Summary

Design-partner feedback **O3** (fastapi-guard half). The guard-core side ships the API-surface audit + `ipinfo_*` deprecation (guard-core PR for O3). This is the consumer-side wiring.

> [!NOTE]
> **Stacked on #92** (the guard-core 3.2.0 adoption). Review/merge #92 first; GitHub will retarget this to `master`. The diff here is only the export + filter change.

### Export single source of truth
`guard.__all__` previously hand-duplicated the 22 names re-exported from `guard_core`, so the two lists could silently drift. Now `__all__` is **derived** from `guard_core.__all__` plus fastapi-guard's two locals (`SecurityMiddleware`, `__version__`):

```python
__all__ = ["__version__", "SecurityMiddleware", *guard_core.__all__]
```

- Re-exports use the explicit `X as X` typed-re-export form (no `# noqa`, no F401); `combine-as-imports` keeps the block tidy.
- A test asserts `__all__` equals guard_core's surface plus the locals; the existing `test_all_exports_importable` already asserts every name is importable — together they make a missing downstream re-export a **loud test failure**, not silent drift.

### Deprecation filter
guard-core 3.2.0 adds a runtime `DeprecationWarning` when the deprecated `ipinfo_token` / `ipinfo_db_path` are set. fastapi-guard's fixtures set `ipinfo_db_path`, so the suite filters that specific warning (the deprecation itself is documented and tested on the guard-core side).

### Verification
- ruff + ruff-format + mypy + vulture + xenon + deptry + bandit: clean
- Full suite: **243 passed, 100% line + branch coverage (0 missed), zero warnings**

Part of the coordinated guard-core 3.2.0 release.