### PR TITLE
docs(behavioral): document the required decorator wiring step (O8)

### DIFF
--- a/docs/tutorial/decorators/behavioral.md
+++ b/docs/tutorial/decorators/behavioral.md
@@ -12,6 +12,41 @@ Behavioral analysis decorators provide advanced monitoring capabilities to detec
 
 ___
 
+Enabling behavioral decorators
+------------------------------
+
+Behavioral decorators are wired into the running middleware in three steps. The third step is what actually makes the rules fire — attaching a decorator without it leaves the rule inert.
+
+```python
+from fastapi import FastAPI
+
+from guard import SecurityConfig, SecurityDecorator, SecurityMiddleware
+
+app = FastAPI()
+
+# 1. Configure and install the middleware
+config = SecurityConfig(enable_penetration_detection=True)
+app.add_middleware(SecurityMiddleware, config=config)
+
+# 2. Build a decorator bound to the same config
+guard_deco = SecurityDecorator(config)
+
+# 3. Wire the decorator into the middleware — REQUIRED
+app.state.guard_decorator = guard_deco
+
+
+@app.get("/api/sensitive")
+@guard_deco.usage_monitor(max_calls=10, window=3600, action="ban")
+async def sensitive_endpoint() -> dict[str, str]:
+    return {"data": "sensitive information"}
+```
+
+**Without `app.state.guard_decorator = guard_deco`, the decorators attach to your routes but their rules never fire** — the middleware has no handle on the decorator, so no behavioral evaluation runs. If you hold the `SecurityMiddleware` instance directly rather than using `add_middleware`, the equivalent call is `middleware.set_decorator_handler(guard_deco)`.
+
+Every decorator example below assumes this wiring is in place.
+
+___
+
 Usage Monitoring
 ----------------
 
@@ -464,6 +499,28 @@ def test_return_pattern():
             else:
                 assert response.status_code == 403  # Blocked after 2 wins
 ```
+
+___
+
+Verifying it works
+------------------
+
+Once the decorator is wired (see [Enabling behavioral decorators](#enabling-behavioral-decorators)), confirm rules are firing end to end:
+
+- **Trip a low-threshold rule.** Set a deliberately small threshold — e.g. `@guard_deco.usage_monitor(max_calls=2, window=60, action="log")` — and call the route a few times. On the threshold breach the engine's `BehavioralProcessor` emits a `decorator_violation` event.
+- **Observe the outcome.** What you see depends on the rule's `action`: `log` writes a log line, `throttle` delays, and `ban` returns `403`. With the Guard Agent enabled, the `decorator_violation` events are also shipped to your dashboard, so you can confirm a rule fired even when its action is `log`.
+- **Trial safely with passive mode.** Set `passive_mode=True` on the `SecurityConfig` to run behavioral rules in log-only mode: violations are recorded with the `[PASSIVE MODE]` prefix instead of blocking, so you can validate thresholds against production traffic before enforcing. See [Security Monitoring](../security/monitoring.md).
+
+If a route's rule never fires, the wiring step is almost always the cause — verify `app.state.guard_decorator` is set to the same decorator that decorates the route.
+
+___
+
+Per-route rules vs. fleet-wide rules
+------------------------------------
+
+The decorators on this page attach rules to a **single route**. To apply a rule to **every route** — for example fleet-wide 404 / scraping tracking — set `SecurityConfig.global_behavior_rules` instead. Global rules need no per-route decorator and no `app.state.guard_decorator` wiring; they are evaluated by the middleware for all traffic.
+
+The two compose: a decorated route is evaluated against both its own decorator rules and any `global_behavior_rules`. Reach for decorators when a limit is specific to an endpoint, and `global_behavior_rules` when a policy should hold everywhere. See the [Security Config reference](../configuration/security-config.md) for the field details.
 
 ___
 

--- a/examples/simple_app/main.py
+++ b/examples/simple_app/main.py
@@ -344,6 +344,9 @@ app.add_middleware(SecurityMiddleware, config=security_config)
 # Initialize security decorator
 guard_decorator = SecurityDecorator(security_config)
 
+# Wire the decorator into the middleware so decorated-route rules actually fire
+app.state.guard_decorator = guard_decorator
+
 
 basic_router = APIRouter(prefix="/basic", tags=["Basic Features"])
 


### PR DESCRIPTION
## Summary

Design-partner feedback **O8** (fastapi-guard half). Behavioral detection fully exists, but the adoption path was broken: behavioral decorators only fire once the decorator is wired into the running middleware via `app.state.guard_decorator = guard_deco`, and that step was documented **only** in the API reference — missing from the behavioral tutorial *and* from the runnable `simple_app` example. A follower could attach rules that silently never fire.

### Changes
- **`docs/tutorial/decorators/behavioral.md`**
  - New **"Enabling behavioral decorators"** section: the full three-step enable sequence (configure + `add_middleware` → build `SecurityDecorator` → `app.state.guard_decorator = guard_deco`), with the wiring step explicitly flagged as required and the failure mode spelled out ("attach but never fire").
  - New **"Verifying it works"** section: trip a low-threshold rule, the `decorator_violation` event, observing the outcome by `action`, and `passive_mode` log-only trial.
  - New **per-route vs. `global_behavior_rules`** contrast.
- **`examples/simple_app/main.py`** — wire `app.state.guard_decorator` so its `usage_monitor` / `return_monitor` / `behavior_analysis` routes are actually functional.

The wiring shown is the exact pattern the end-to-end decorator tests use (`tests/test_decorators/test_behavioral.py`). The companion guard-core PR fixes the `@security.behavioral` → `behavior_analysis` doc-bug.

### Scope
Docs + example wiring only — no engine logic change, no new config/decorator surface. Markdown lint + ruff clean.