### PR TITLE
refactor(exports): single-source __all__ from guard_core (O3)

### DIFF
--- a/guard/__init__.py
+++ b/guard/__init__.py
@@ -1,61 +1,36 @@
-from importlib.metadata import PackageNotFoundError
-from importlib.metadata import version as _pkg_version
+from importlib.metadata import PackageNotFoundError, version as _pkg_version
 
+import guard_core
 from guard_core import (
-    BehaviorRule,
-    BehaviorTracker,
-    CloudManager,
-    GeoIPHandler,
-    GuardRequest,
-    GuardResponse,
-    GuardResponseFactory,
-    IPBanManager,
-    IPInfoManager,
-    RateLimitManager,
-    RedisHandlerProtocol,
-    RedisManager,
-    RouteConfig,
-    SecurityConfig,
-    SecurityDecorator,
-    SecurityHeadersManager,
-    cloud_handler,
-    ip_ban_manager,
-    rate_limit_handler,
-    redis_handler,
-    security_headers_manager,
-    sus_patterns_handler,
+    BehaviorRule as BehaviorRule,
+    BehaviorTracker as BehaviorTracker,
+    CloudManager as CloudManager,
+    GeoIPHandler as GeoIPHandler,
+    GuardRequest as GuardRequest,
+    GuardResponse as GuardResponse,
+    GuardResponseFactory as GuardResponseFactory,
+    IPBanManager as IPBanManager,
+    IPInfoManager as IPInfoManager,
+    RateLimitManager as RateLimitManager,
+    RedisHandlerProtocol as RedisHandlerProtocol,
+    RedisManager as RedisManager,
+    RouteConfig as RouteConfig,
+    SecurityConfig as SecurityConfig,
+    SecurityDecorator as SecurityDecorator,
+    SecurityHeadersManager as SecurityHeadersManager,
+    cloud_handler as cloud_handler,
+    ip_ban_manager as ip_ban_manager,
+    rate_limit_handler as rate_limit_handler,
+    redis_handler as redis_handler,
+    security_headers_manager as security_headers_manager,
+    sus_patterns_handler as sus_patterns_handler,
 )
 
-from guard.middleware import SecurityMiddleware
+from guard.middleware import SecurityMiddleware as SecurityMiddleware
 
 try:
     __version__ = _pkg_version("fastapi-guard")
 except PackageNotFoundError:
     __version__ = "0.0.0+unknown"
 
-__all__ = [
-    "__version__",
-    "SecurityMiddleware",
-    "SecurityConfig",
-    "SecurityDecorator",
-    "RouteConfig",
-    "BehaviorTracker",
-    "BehaviorRule",
-    "ip_ban_manager",
-    "IPBanManager",
-    "cloud_handler",
-    "CloudManager",
-    "IPInfoManager",
-    "rate_limit_handler",
-    "RateLimitManager",
-    "redis_handler",
-    "RedisManager",
-    "security_headers_manager",
-    "SecurityHeadersManager",
-    "sus_patterns_handler",
-    "GeoIPHandler",
-    "RedisHandlerProtocol",
-    "GuardRequest",
-    "GuardResponse",
-    "GuardResponseFactory",
-]
+__all__ = ["__version__", "SecurityMiddleware", *guard_core.__all__]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,6 +132,9 @@ select = [
     "I",
 ]
 
+[tool.ruff.lint.isort]
+combine-as-imports = true
+
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]
@@ -140,6 +143,9 @@ asyncio_default_fixture_loop_scope = "function"
 addopts = "--cov=guard --cov-branch --cov-report=term-missing"
 markers = [
     "asyncio: mark tests as async"
+]
+filterwarnings = [
+    "ignore:ipinfo_.* is deprecated:DeprecationWarning",
 ]
 
 [tool.coverage.run]

--- a/tests/test_reexports.py
+++ b/tests/test_reexports.py
@@ -8,6 +8,18 @@ def test_all_exports_importable() -> None:
         assert hasattr(guard, name), f"{name} not found in guard module"
 
 
+def test_all_derives_from_guard_core_exports() -> None:
+    import guard_core
+
+    import guard
+
+    assert set(guard.__all__) == {
+        "__version__",
+        "SecurityMiddleware",
+        *guard_core.__all__,
+    }
+
+
 def test_security_middleware_importable() -> None:
     from guard.middleware import SecurityMiddleware
 


### PR DESCRIPTION
## Summary

Design-partner feedback **O3** (fastapi-guard half). Supersedes #93, which GitHub auto-closed when its stacked base (`feat/agent-init-clarity`, #92) was merged + deleted. Same change, rebased directly onto `master`.

Derive `guard.__all__` from `guard_core.__all__` plus the two fastapi-guard locals instead of hand-duplicating the 22 re-exported names, so the lists can't silently drift. Re-exports use the explicit `X as X` typed form (no `# noqa`); `combine-as-imports` keeps the block tidy. A test asserts `__all__` equals guard_core's surface plus the locals; the existing test already asserts every name is importable.

Also filters guard-core 3.2.0's new `ipinfo_*` `DeprecationWarning` in the test suite (fixtures set `ipinfo_db_path`).

Full suite: **243 passed, 100% line + branch, zero warnings** (validated pre-rebase).

Part of the coordinated guard-core 3.2.0 release.