### PR TITLE
ci(docs): serialize docs deploys to prevent gh-pages races

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,6 +20,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: docs-deploy
+  cancel-in-progress: false
+
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Batch-merging PRs triggered several concurrent `mike deploy --push` runs that raced on the gh-pages ref (the losers failed with "cannot lock ref"). A workflow-level `concurrency` group serializes them (cancel-in-progress: false so none is cancelled mid-push). The already-failed run was re-deployed manually; this prevents recurrence.