### PR TITLE
fix(tests): repair behavioural tests against guard-core 3.7.0

### DIFF
--- a/tests/test_decorators/test_middleware_integration.py
+++ b/tests/test_decorators/test_middleware_integration.py
@@ -264,6 +264,7 @@ async def test_behavioral_rules_without_guard_decorator() -> None:
     middleware.guard_decorator = None
 
     mock_request = Mock()
+    mock_request.state.guard_decorator = None
     mock_route_config = Mock()
     mock_route_config.behavior_rules = [BehaviorRule("usage", threshold=5, window=3600)]
 
@@ -291,6 +292,7 @@ async def test_behavioral_usage_rules_with_decorator() -> None:
     }
     mock_request.method = "GET"
     mock_request.url.path = "/test"
+    mock_request.state.guard_decorator = mock_guard_decorator
 
     mock_route_config = Mock()
     usage_rule = BehaviorRule("usage", threshold=5, window=3600)
@@ -327,6 +329,7 @@ async def test_behavioral_return_rules_with_decorator() -> None:
     }
     mock_request.method = "GET"
     mock_request.url.path = "/test"
+    mock_request.state.guard_decorator = mock_guard_decorator
 
     mock_response = Mock()
     mock_route_config = Mock()


### PR DESCRIPTION
## Why master is red

guard-core 3.7.0 fixed `BehavioralProcessor._behavior_tracker()` to resolve the tracker from `request.state.guard_decorator`. Behavioural rules that were previously inert now actually execute — that is the point of the fix — but it means three mock-based tests here stop short-circuiting and fail:

```
FAILED tests/test_decorators/test_middleware_integration.py::test_behavioral_rules_without_guard_decorator - TypeError: object Mock can't be used in 'await' expression
FAILED tests/test_decorators/test_middleware_integration.py::test_behavioral_usage_rules_with_decorator - TypeError: object Mock can't be used in 'await' expression
FAILED tests/test_decorators/test_middleware_integration.py::test_behavioral_return_rules_with_decorator - TypeError: object Mock can't be used in 'await' expression
```

CI floats `guard-core`, so this appeared the moment 3.7.0 hit PyPI.

## Cause

A bare `Mock()` request auto-creates `request.state.guard_decorator`, so the new fallback finds a Mock "decorator" and takes `Mock().behavior_tracker` — a plain `Mock`, not the `AsyncMock` tracker each test carefully configures on its own `mock_guard_decorator`. `await` on that raises `TypeError`.

The tests set `middleware.guard_decorator = mock_guard_decorator`, which never reached the behavioural context; the context is snapshotted in `__init__`. They passed only because the tracker resolved to `None` and the processor returned before touching any of it — they were asserting against dead code.

## Fix

Test-only. Point `request.state.guard_decorator` at the decorator each test already builds, so the configured `AsyncMock` tracker is the one used, and pin it to `None` in the no-decorator test so "no tracker anywhere" still means that. The assertions become meaningful instead of vacuous.

**No runtime impact.** `SecurityMiddleware` is unchanged and released 7.3.1 behaviour is correct — only these mock-based tests encoded the dead path.

## Verification

Against guard-core 3.7.0 installed: 267 passed, 100% line and branch coverage on `guard/middleware.py`. The same class of stale behavioural test was fixed in flaskapi-guard alongside this; djangoapi-guard was unaffected.