### PR TITLE
docs(security): document the app-server forwarded-header prerequisite

### DIFF
--- a/docs/tutorial/security/proxy-security.md
+++ b/docs/tutorial/security/proxy-security.md
@@ -25,6 +25,22 @@ Common security issues include:
 
 ___
 
+Prerequisite: Your App Server Must Not Pre-Resolve the Client
+---------------------------------------------------------------
+
+FastAPI Guard reads the connecting IP from `request.client.host`, which is whatever your ASGI server put in `scope["client"]` — by the time a request reaches `SecurityMiddleware`, the server has already run. Several ASGI/WSGI servers rewrite that value themselves from `X-Forwarded-For` before any application code runs. uvicorn is the clearest example: it defaults to `proxy_headers=True` with `forwarded_allow_ips="127.0.0.1"`, so a reverse proxy connecting from loopback (a same-host `proxy_pass`, the common case) has its `X-Forwarded-For` applied to `scope["client"]` upstream of FastAPI Guard.
+
+When that happens, `trusted_proxies` unset does **not** mean "`X-Forwarded-For` is never trusted" — the server already trusted it, so an attacker's own forged header value becomes the connecting IP as far as rate limiting, IP bans, and every other check are concerned. guard-core detects the fingerprint of this condition (the connecting IP appearing inside its own `X-Forwarded-For` chain, which a real proxy never produces) and logs one warning naming the fix, but it cannot recover the true peer once the server has already overwritten it.
+
+**Fix**: disable the server's own forwarded-header handling and let `trusted_proxies` be the single authority:
+
+- uvicorn: `--no-proxy-headers` on the CLI, or `proxy_headers=False` in `uvicorn.run(...)`.
+- Gunicorn, Hypercorn, and other WSGI/ASGI servers have equivalent forwarded-header/proxy-trust settings — disable them the same way.
+
+With the server's own handling off, its access log will show the proxy's address rather than the original client — that's expected, since `X-Forwarded-For` is no longer applied before the request reaches your application.
+
+___
+
 Secure Configuration
 --------------------
 

--- a/tests/test_proxy_header_preemption_e2e.py
+++ b/tests/test_proxy_header_preemption_e2e.py
@@ -1,0 +1,72 @@
+from typing import Any
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from guard_core.models import SecurityConfig
+from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
+
+from guard.middleware import SecurityMiddleware
+
+RATE_LIMIT = 3
+ATTEMPTS = 12
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+    config = SecurityConfig(
+        enable_rate_limiting=True,
+        rate_limit=RATE_LIMIT,
+        rate_limit_window=60,
+        enable_redis=False,
+        enable_ip_banning=False,
+        enable_penetration_detection=False,
+    )
+    app.add_middleware(SecurityMiddleware, config=config)
+
+    @app.get("/api/login")
+    async def login() -> dict[str, bool]:
+        return {"ok": True}
+
+    return app
+
+
+def _drive_with_rotating_forwarded_for(
+    *, wrap_in_uvicorn_proxy_headers: bool
+) -> list[int]:
+    """One attacker, one connecting peer (127.0.0.1), a fresh X-Forwarded-For
+    value on every request, trusted_proxies left unset throughout."""
+    asgi: Any = _build_app()
+    if wrap_in_uvicorn_proxy_headers:
+        asgi = ProxyHeadersMiddleware(asgi, trusted_hosts="127.0.0.1")
+
+    codes = []
+    with TestClient(asgi, client=("127.0.0.1", 5555)) as client:
+        for i in range(ATTEMPTS):
+            response = client.get(
+                "/api/login", headers={"X-Forwarded-For": f"9.9.{i}.{i}"}
+            )
+            codes.append(response.status_code)
+    return codes
+
+
+def test_uvicorns_own_proxy_headers_let_rotating_forwarded_for_evade_rate_limit() -> (
+    None
+):
+    """This is the regression: uvicorn's default proxy_headers=True rewrites
+    scope["client"] from X-Forwarded-For before SecurityMiddleware ever runs,
+    so trusted_proxies unset does not mean the header is never trusted — every
+    forged value earns the attacker a fresh rate-limit bucket and the limiter
+    never engages."""
+    codes = _drive_with_rotating_forwarded_for(wrap_in_uvicorn_proxy_headers=True)
+    assert codes.count(200) == ATTEMPTS
+    assert codes.count(429) == 0
+
+
+def test_disabling_uvicorns_proxy_headers_restores_the_rate_limit() -> None:
+    """The documented remediation actually works: with uvicorn's own
+    forwarded-header handling off, the connecting peer stays 127.0.0.1 for
+    every request regardless of X-Forwarded-For, so the same SecurityMiddleware
+    config correctly buckets all of them together and the limiter engages."""
+    codes = _drive_with_rotating_forwarded_for(wrap_in_uvicorn_proxy_headers=False)
+    assert codes.count(200) == RATE_LIMIT
+    assert codes.count(429) == ATTEMPTS - RATE_LIMIT


### PR DESCRIPTION
Companion to rennf93/guard-core#49, which adds the runtime warning in the engine. This side carries the operator documentation and the end-to-end regression that proves the remediation works.

## Why

`guard/adapters.py:35-36` returns `self._request.client.host`, which feeds `guard_core`'s `extract_client_ip` and therefore the whole `trusted_proxies` decision. uvicorn applies `X-Forwarded-For` to `scope["client"]` *before* any middleware — `proxy_headers=True, forwarded_allow_ips="127.0.0.1"` by default, and a same-host reverse proxy connects from loopback. So a value guard-core treats as the socket peer can already be attacker-supplied, and `trusted_proxies` left unset does **not** mean "the header is never trusted".

We had never documented this. `proxy_headers` / `forwarded-allow-ips` appeared nowhere in this repo or guard-core before now.

## What's here

**`docs/tutorial/security/proxy-security.md`** — a new prerequisite section immediately after "The Problem": the uvicorn default, both consequences (rate-limit bypass with `trusted_proxies` unset, and false `spoofing_detected` telemetry on legitimate traffic once the server pre-resolves the peer), the detection fingerprint, the uvicorn/gunicorn/hypercorn remediation, and the visible side effect that the server access log will then show the proxy's address.

**`tests/test_proxy_header_preemption_e2e.py`** — drives the real `SecurityMiddleware` (`rate_limit=3/60s`, `trusted_proxies` unset), 12 requests from one attacker rotating `X-Forwarded-For`, peer=127.0.0.1:

- `test_uvicorns_own_proxy_headers_let_rotating_forwarded_for_evade_rate_limit` — wrapped in uvicorn's actual `ProxyHeadersMiddleware`: all 12 return 200, limiter fully bypassed
- `test_disabling_uvicorns_proxy_headers_restores_the_rate_limit` — identical config without the wrapper: exactly 3×200 then 9×429

The second test is the one that matters long-term: it fails if the documented remediation ever stops working.

## Verification

- Full suite: `269 passed`, 100% coverage on `guard/lifespan.py` and `guard/middleware.py`
- `ruff format` / `ruff check` / `vulture` / `xenon` / `deptry` / `bandit -r guard -ll` clean
- Whole-repo `mypy .` is blocked on `master` by a pre-existing `Duplicate module named "main"` (`manual_testing/stress_test/main.py` vs `examples/simple_app/main.py`), so the new test was type-checked scoped: clean