### PR TITLE
test: assert guard-core 3.15.0 redis_fail_open semantics

### DIFF
--- a/tests/test_middleware/test_security_middleware.py
+++ b/tests/test_middleware/test_security_middleware.py
@@ -9,6 +9,7 @@ import pytest
 from fastapi import FastAPI, Request, Response, status
 from fastapi.responses import JSONResponse
 from guard_core.detection_result import DetectionResult
+from guard_core.exceptions import GuardRedisError
 from guard_core.handlers.cloud_handler import cloud_handler
 from guard_core.handlers.ipinfo_handler import IPInfoManager
 from guard_core.handlers.ratelimit_handler import rate_limit_handler
@@ -1698,7 +1699,6 @@ async def test_rate_limiter_redis_errors(security_config_redis: SecurityConfig) 
     with (
         patch.object(handler.redis_handler, "get_connection") as mock_get_connection,
         patch.object(logging.Logger, "error") as mock_error,
-        patch.object(logging.Logger, "info") as mock_info,
     ):
         mock_conn = AsyncMock()
         mock_conn.__aenter__ = AsyncMock(
@@ -1708,15 +1708,25 @@ async def test_rate_limiter_redis_errors(security_config_redis: SecurityConfig) 
 
         handler.rate_limit_script_sha = "test_script_sha"
 
+        with pytest.raises(GuardRedisError):
+            await handler.check_rate_limit(
+                guard_request, "192.168.1.1", create_error_response
+            )
+
+        mock_error.assert_called_once()
+        assert "Redis rate limiting error" in mock_error.call_args[0][0]
+
+        mock_error.reset_mock()
+        config.redis_fail_open = True
+
         result = await handler.check_rate_limit(
             guard_request, "192.168.1.1", create_error_response
         )
 
         assert result is None
+        mock_error.assert_not_called()
 
-        mock_error.assert_called_once()
-        assert "Redis rate limiting error" in mock_error.call_args[0][0]
-        mock_info.assert_called_once_with("Falling back to in-memory rate limiting")
+        config.redis_fail_open = False
 
     with (
         patch.object(handler.redis_handler, "get_connection") as mock_get_connection,
@@ -1726,14 +1736,23 @@ async def test_rate_limiter_redis_errors(security_config_redis: SecurityConfig) 
         mock_conn.__aenter__ = AsyncMock(side_effect=Exception("Unexpected error"))
         mock_get_connection.return_value = mock_conn
 
+        with pytest.raises(GuardRedisError):
+            await handler.check_rate_limit(
+                guard_request, "192.168.1.1", create_error_response
+            )
+
+        mock_error.assert_called_once()
+        assert "Unexpected error in rate limiting" in mock_error.call_args[0][0]
+
+        mock_error.reset_mock()
+        config.redis_fail_open = True
+
         result = await handler.check_rate_limit(
             guard_request, "192.168.1.1", create_error_response
         )
 
         assert result is None
-
-        mock_error.assert_called_once()
-        assert "Unexpected error in rate limiting" in mock_error.call_args[0][0]
+        mock_error.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -543,6 +543,9 @@ async def test_guard_websocket_reuses_the_middlewares_redis_manager(
     )
 
     with TestClient(app, client=("127.0.0.1", 12345)) as client:
+        assert client.portal is not None
+        client.portal.call(RedisManager(config).initialize)
+
         with client.websocket_connect("/ws") as websocket:
             assert websocket.receive_text() == "connected"
 
@@ -621,7 +624,6 @@ async def test_make_guard_websocket_uses_the_given_redis_handler(
     config = security_config_redis
 
     redis_handler = RedisManager(config)
-    await redis_handler.initialize()
 
     captured: dict[str, Any] = {}
 
@@ -644,6 +646,9 @@ async def test_make_guard_websocket_uses_the_given_redis_handler(
         await websocket.send_text("connected")
 
     with TestClient(app, client=("127.0.0.1", 12345)) as client:
+        assert client.portal is not None
+        client.portal.call(redis_handler.initialize)
+
         with client.websocket_connect("/ws") as websocket:
             assert websocket.receive_text() == "connected"
 
@@ -651,7 +656,6 @@ async def test_make_guard_websocket_uses_the_given_redis_handler(
             with client.websocket_connect("/ws"):
                 pass
 
-        assert client.portal is not None
         client.portal.call(redis_handler.close)
 
     assert exc_info.value.code == 1008


### PR DESCRIPTION
Delivers issue: #126
Closes #126

## Description

CI on master and PR #125 fails identically since guard-core 3.15.0 hit PyPI (2026-08-27 15:52Z): 3 failed, 381 passed. `pyproject.toml` pins `guard-core>=3.14.0`, so every run resolves 3.15.0, whose rate limiter now honours `SecurityConfig.redis_fail_open` (default False): on a Redis failure it raises `GuardRedisError` instead of silently falling back to the in-memory window. Two of the three failures share a second, previously latent cause: a Redis-backed `RedisManager` initialized on the pytest-asyncio test loop but used by the app inside `TestClient`'s own portal thread loop, which redis-py's async client cannot tolerate. 3.14.0 swallowed that mismatch into the same silent fallback; 3.15.0's fail-secure default now surfaces it as a WebSocket 1013 close.

Root cause per test:

- `tests/test_middleware/test_security_middleware.py::test_rate_limiter_redis_errors` called `RateLimitManager.check_rate_limit` directly (bypassing the pipeline-level `GuardRedisError` handling `guard_core.core.checks.pipeline.SecurityCheckPipeline._handle_check_error` already provides for real HTTP traffic) and asserted the 3.14.0 silent-fallback return value. Rewritten to assert `GuardRedisError` is raised with the default `redis_fail_open=False`, and that the old fallback (`result is None`) still holds with `redis_fail_open=True`, for both the `RedisError` and generic-`Exception` failure paths.
- `tests/test_websocket.py::test_guard_websocket_reuses_the_middlewares_redis_manager` and `::test_make_guard_websocket_uses_the_given_redis_handler` initialized their `RedisManager` in the test coroutine's own event loop, then exercised it from inside `TestClient`'s portal thread, which runs on a different loop. Fixed by running `RedisManager.initialize` through `client.portal.call(...)`, matching the file's existing convention of running `redis_handler.close()` through the same portal.

No library code changed (`guard/` untouched); `guard/websocket.py`'s `_guarded_redis_call` already correctly maps `GuardRedisError` to fail-open/fail-secure per `redis_fail_open` and `fail_secure`, confirmed by reading it during root-causing.

## How Has This Been Tested

Reproduced the exact CI failure locally against guard-core 3.15.0 (`uv pip show guard-core` reports 3.15.0; lock already resolved it, no lock change needed), then verified the fix:

```
tests/test_middleware/test_security_middleware.py::test_rate_limiter_redis_errors tests/test_websocket.py -q
27 passed in 1.21s
```

Full suite:

```
384 passed in 255.73s (0:04:15)
TOTAL coverage 745 stmts, 194 branches: 100%
```

Pre-commit (ruff-format, ruff, mypy, vulture, bandit, radon-cc, xenon, deptry), all green:

```
ruff-format..............................................................Passed
ruff.....................................................................Passed
mypy.....................................................................Passed
vulture..................................................................Passed
bandit...................................................................Passed
radon-cyclomatic-complexity..............................................Passed
xenon....................................................................Passed
deptry...................................................................Passed
```